### PR TITLE
[update] v0.13.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,30 @@
+# v0.13.1
+## Update mods
+* AE2 Unofficial Extended Life
+* GregTech Food Option
+
+## Change config
+### AE2WirelessTerminals
+* DropsBooster -> all off
+* UseOldInfinityMechanic -> true
+
+## GregTech
+* casingsActiveEmissiveTextures -> false
+
+## Modpack fix
+* GTCEu P2P description is in the other section.
+* Adjusted the way Naquadah Rocket Fuel is created.
+* Some ore could not be mined at the Void Ore Drilling Plant.
+* Changed the way the Void Ore Drilling Plant is assembled and the recipe on the assembly line.
+* Adjusted the mining time of the Void Ore Drilling Plant.
+* The Void Ore Drilling Plant now requires 10L of Dew of the Void to operate.
+
+## Fix recipes
+### Open Computers
+* Transistor
+
+* * *
+
 # v0.13.0
 ## New mods
 * AppleCore

--- a/manifest.json
+++ b/manifest.json
@@ -11,7 +11,7 @@
   "manifestType": "minecraftModpack",
   "manifestVersion": 1,
   "name": "GregTech Expert 2",
-  "version": "v0.13.0",
+  "version": "v0.13.1",
   "author": "tier940",
   "files": [
     {
@@ -106,7 +106,7 @@
     },
     {
       "projectID": 570458,
-      "fileID": 3632074,
+      "fileID": 3644382,
       "required": true
     },
     {
@@ -266,7 +266,7 @@
     },
     {
       "projectID": 477021,
-      "fileID": 3636751,
+      "fileID": 3644475,
       "required": true
     },
     {

--- a/overrides/config/AE2WirelessTerminals.cfg
+++ b/overrides/config/AE2WirelessTerminals.cfg
@@ -14,7 +14,7 @@ general {
     B:DisableBoosterRecipe=true
 
     # Should Dragons drop Infinity Booster Card? [default: true]
-    B:DragonDropsBooster=true
+    B:DragonDropsBooster=false
 
     # Enable Infinity Booster Card [default: true]
     B:EnableBooster=true
@@ -26,7 +26,7 @@ general {
     I:EndermanBoosterDropChance=5
 
     # Will Enderman randomly drop infinity booster cards on death? [default: true]
-    B:EndermanDropBoosters=true
+    B:EndermanDropBoosters=false
 
     # Amount of Infinity Energy Consumed every 10 ticks when not in range of a WAP [range: 5 ~ 100, default: 15]
     I:InfinityEnergyDrainAmount=15
@@ -35,13 +35,13 @@ general {
     I:InfinityEnergyPerBooster=100
 
     # If true, then simply inserting 1 Infinity Booster Card into the slot, will give limitless infinite range. [default: false]
-    B:UseOldInfinityMechanic=false
+    B:UseOldInfinityMechanic=true
 
     # Percentage chance that booster card will drop upon killing a wither. (between 1 and 100) [range: 1 ~ 100, default: 30]
     I:WitherBoosterDropChance=30
 
     # Should Withers drop Infinity Booster Card? [default: true]
-    B:WitherDropsBooster=true
+    B:WitherDropsBooster=false
 }
 
 

--- a/overrides/config/AppliedEnergistics2/AppliedEnergistics2.cfg
+++ b/overrides/config/AppliedEnergistics2/AppliedEnergistics2.cfg
@@ -15,6 +15,81 @@ battery {
 }
 
 
+##########################################################################################################
+# blockingmode
+#--------------------------------------------------------------------------------------------------------#
+# Map of items to not block when blockingmode is enabled.
+# [modid]
+# modid:item:metadata(optional,default:0)
+# Supports more than one modid, so you can block different things between, for example, gregtech or enderio
+##########################################################################################################
+
+blockingmode {
+    # NonBlockingItems
+    S:nonBlockingItems <
+        [gregtech]
+        gregtech:shape.mold.plate
+        gregtech:shape.mold.gear
+        gregtech:shape.mold.credit
+        gregtech:shape.mold.bottle
+        gregtech:shape.mold.ingot
+        gregtech:shape.mold.ball
+        gregtech:shape.mold.block
+        gregtech:shape.mold.nugget
+        gregtech:shape.mold.cylinder
+        gregtech:shape.mold.anvil
+        gregtech:shape.mold.name
+        gregtech:shape.mold.gear.small
+        gregtech:shape.mold.rotor
+        gregtech:shape.extruder.plate
+        gregtech:shape.extruder.rod
+        gregtech:shape.extruder.bolt
+        gregtech:shape.extruder.ring
+        gregtech:shape.extruder.cell
+        gregtech:shape.extruder.ingot
+        gregtech:shape.extruder.wire
+        gregtech:shape.extruder.pipe.tiny
+        gregtech:shape.extruder.pipe.small
+        gregtech:shape.extruder.pipe.normal
+        gregtech:shape.extruder.pipe.large
+        gregtech:shape.extruder.pipe.huge
+        gregtech:shape.extruder.block
+        gregtech:shape.extruder.sword
+        gregtech:shape.extruder.pickaxe
+        gregtech:shape.extruder.shovel
+        gregtech:shape.extruder.axe
+        gregtech:shape.extruder.hoe
+        gregtech:shape.extruder.hammer
+        gregtech:shape.extruder.file
+        gregtech:shape.extruder.saw
+        gregtech:shape.extruder.gear
+        gregtech:shape.extruder.bottle
+        gregtech:shape.extruder.foil
+        gregtech:shape.extruder.gear_small
+        gregtech:shape.extruder.rod_long
+        gregtech:shape.extruder.rotor
+        gregtech:glass_lens.white
+        gregtech:glass_lens.orange
+        gregtech:glass_lens.magenta
+        gregtech:glass_lens.light_blue
+        gregtech:glass_lens.yellow
+        gregtech:glass_lens.lime
+        gregtech:glass_lens.pink
+        gregtech:glass_lens.gray
+        gregtech:glass_lens.light_gray
+        gregtech:glass_lens.cyan
+        gregtech:glass_lens.purple
+        gregtech:glass_lens.blue
+        gregtech:glass_lens.brown
+        gregtech:glass_lens.green
+        gregtech:glass_lens.red
+        gregtech:glass_lens.black
+        contenttweaker:smallgearextrudershape
+        contenttweaker:creativeportabletankmold
+     >
+}
+
+
 client {
     # Possible Values: AE, EU, RF, GTCEU
     S:PowerUnit=GTCEU
@@ -255,8 +330,6 @@ features {
 
     craftingfeatures {
         B:CraftingCPU=true
-
-        # Use CraftingManager to find an alternative recipe, after a pattern rejected an ingredient. Should be enabled to avoid issues, but can have a minor performance impact.
         B:CraftingManagerFallback=true
         B:MolecularAssembler=true
         B:Patterns=true

--- a/overrides/config/AppliedEnergistics2/CustomRecipes.cfg
+++ b/overrides/config/AppliedEnergistics2/CustomRecipes.cfg
@@ -1,7 +1,7 @@
 # Configuration file
 
 cache {
-    S:digest=f62a3da5eff86bc7802ff799ffc6bbae
+    S:digest=605720975b26837a6e106f050df23ab2
 
     # Caching can save processing time, if there are a lot of items. [default: true]
     B:enableCache=true

--- a/overrides/config/AppliedEnergistics2/VersionChecker.cfg
+++ b/overrides/config/AppliedEnergistics2/VersionChecker.cfg
@@ -3,7 +3,7 @@
 cache {
     # Waits as many hours, until it checks again. [range: 0 ~ 168, default: 24]
     I:interval=24
-    S:lastCheck=1644409896638
+    S:lastCheck=1644500454248
 }
 
 

--- a/overrides/config/AppliedEnergistics2/items.csv
+++ b/overrides/config/AppliedEnergistics2/items.csv
@@ -1244,16 +1244,19 @@ extracells:pattern.fluid:0, ME Fluid Pattern: Starch-Filled Water
 extracells:pattern.fluid:0, ME Fluid Pattern: Potato Juice
 extracells:pattern.fluid:0, ME Fluid Pattern: Purple Drink
 extracells:pattern.fluid:0, ME Fluid Pattern: Olive Oil
+extracells:pattern.fluid:0, ME Fluid Pattern: Liquid Fat (Stearin)
 extracells:pattern.fluid:0, ME Fluid Pattern: Butter
 extracells:pattern.fluid:0, ME Fluid Pattern: Sludge
 extracells:pattern.fluid:0, ME Fluid Pattern: Cane Syrup
 extracells:pattern.fluid:0, ME Fluid Pattern: Leninade
 extracells:pattern.fluid:0, ME Fluid Pattern: Yolk
+extracells:pattern.fluid:0, ME Fluid Pattern: Stearic Acid
 extracells:pattern.fluid:0, ME Fluid Pattern: Chloroauric Acid
 extracells:pattern.fluid:0, ME Fluid Pattern: Whey
 extracells:pattern.fluid:0, ME Fluid Pattern: Perchloric Acid
 extracells:pattern.fluid:0, ME Fluid Pattern: Whey/Salt Water Mix
 extracells:pattern.fluid:0, ME Fluid Pattern: Moist Air
+extracells:pattern.fluid:0, ME Fluid Pattern: Sodium Stearate (Soap)
 extracells:pattern.fluid:0, ME Fluid Pattern: Hot Frying Oil
 extracells:pattern.fluid:0, ME Fluid Pattern: Rabbit Stew
 extracells:pattern.fluid:0, ME Fluid Pattern: Crude Rennet Solution
@@ -6326,10 +6329,26 @@ appliedenergistics2:facade:0, Cable Facade - Block of Nickel
 appliedenergistics2:facade:0, Cable Facade - Block of Niobium
 appliedenergistics2:facade:0, Cable Facade - Block of Osmium
 appliedenergistics2:facade:0, Cable Facade - Block of Palladium
-appliedenergistics2:facade:0, Cable Facade - Block of Chrome
-appliedenergistics2:facade:0, Cable Facade - Block of Cobalt
-appliedenergistics2:facade:0, Cable Facade - Block of Copper
-appliedenergistics2:facade:0, Cable Facade - Block of Darmstadtium
+appliedenergistics2:facade:0, Cable Facade - Block of Battery Alloy
+appliedenergistics2:facade:0, Cable Facade - Block of Blue Topaz
+appliedenergistics2:facade:0, Cable Facade - Block of Brass
+appliedenergistics2:facade:0, Cable Facade - Block of Bronze
+appliedenergistics2:facade:0, Cable Facade - Block of Charcoal
+appliedenergistics2:facade:0, Cable Facade - Block of Cinnabar
+appliedenergistics2:facade:0, Cable Facade - Block of Stellite-100
+appliedenergistics2:facade:0, Cable Facade - Block of Watertight Steel
+appliedenergistics2:facade:0, Cable Facade - Block of Maraging Steel 300
+appliedenergistics2:facade:0, Cable Facade - Block of Hastelloy-C276
+appliedenergistics2:facade:0, Cable Facade - Block of Hastelloy-X
+appliedenergistics2:facade:0, Cable Facade - Block of Trinaquadalloy
+appliedenergistics2:facade:0, Cable Facade - Block of Zeron-100
+appliedenergistics2:facade:0, Cable Facade - Block of Titanium Carbide
+appliedenergistics2:facade:0, Cable Facade - Block of Cupronickel
+appliedenergistics2:facade:0, Cable Facade - Block of Electrum
+appliedenergistics2:facade:0, Cable Facade - Block of Green Sapphire
+appliedenergistics2:facade:0, Cable Facade - Block of Grossular
+appliedenergistics2:facade:0, Cable Facade - Block of Rutile
+appliedenergistics2:facade:0, Cable Facade - Block of Invar
 appliedenergistics2:facade:0, Cable Facade - Block of Enderpearl
 appliedenergistics2:facade:0, Cable Facade - Block of Magnetic Neodymium
 appliedenergistics2:facade:0, Cable Facade - Block of Magnetic Samarium
@@ -6341,14 +6360,11 @@ appliedenergistics2:facade:0, Cable Facade - Block of Samarium Iron Arsenic Oxid
 appliedenergistics2:facade:0, Cable Facade - Block of Indium Tin Barium Titanium Cuprate
 appliedenergistics2:facade:0, Cable Facade - Block of Uranium Rhodium Dinaquadide
 appliedenergistics2:facade:0, Cable Facade - Block of Enriched Naquadah Trinium Europium Duranide
-appliedenergistics2:facade:0, Cable Facade - Block of Olivine
-appliedenergistics2:facade:0, Cable Facade - Block of Opal
-appliedenergistics2:facade:0, Cable Facade - Block of Amethyst
-appliedenergistics2:facade:0, Cable Facade - Block of Apatite
-appliedenergistics2:facade:0, Cable Facade - Block of Black Steel
-appliedenergistics2:facade:0, Cable Facade - Block of Damascus Steel
-appliedenergistics2:facade:0, Cable Facade - Block of Tungstensteel
-appliedenergistics2:facade:0, Cable Facade - Block of Cobalt Brass
+appliedenergistics2:facade:0, Cable Facade - Block of Tantalum Carbide
+appliedenergistics2:facade:0, Cable Facade - Block of Molybdenum Disilicide
+appliedenergistics2:facade:0, Cable Facade - Block of HSLA Steel
+appliedenergistics2:facade:0, Cable Facade - Block of Titanium Tungsten Carbide
+appliedenergistics2:facade:0, Cable Facade - Block of Incoloy-MA956
 appliedenergistics2:facade:0, Cable Facade - Block of Tin
 appliedenergistics2:facade:0, Cable Facade - Block of Titanium
 appliedenergistics2:facade:0, Cable Facade - Block of Tungsten
@@ -6361,44 +6377,26 @@ appliedenergistics2:facade:0, Cable Facade - Block of Naquadah
 appliedenergistics2:facade:0, Cable Facade - Block of Enriched Naquadah
 appliedenergistics2:facade:0, Cable Facade - Block of Naquadria
 appliedenergistics2:facade:0, Cable Facade - Block of Neutronium
-appliedenergistics2:facade:0, Cable Facade - Block of Malachite
-appliedenergistics2:facade:0, Cable Facade - Block of Magnetic Iron
-appliedenergistics2:facade:0, Cable Facade - Block of Tungstencarbide
-appliedenergistics2:facade:0, Cable Facade - Block of Battery Alloy
-appliedenergistics2:facade:0, Cable Facade - Block of Blue Topaz
-appliedenergistics2:facade:0, Cable Facade - Block of Brass
-appliedenergistics2:facade:0, Cable Facade - Block of Bronze
-appliedenergistics2:facade:0, Cable Facade - Block of Charcoal
-appliedenergistics2:facade:0, Cable Facade - Block of Cinnabar
-appliedenergistics2:facade:0, Cable Facade - Block of Melodic Alloy
-appliedenergistics2:facade:0, Cable Facade - Block of Stellar Alloy
-appliedenergistics2:facade:0, Cable Facade - Block of Crystalline Pink Slime
-appliedenergistics2:facade:0, Cable Facade - Block of Energetic Silver
-appliedenergistics2:facade:0, Cable Facade - Block of Vivid Alloy
-appliedenergistics2:facade:0, Cable Facade - Block of Silicon
-appliedenergistics2:facade:0, Cable Facade - Block of Silver
-appliedenergistics2:facade:0, Cable Facade - Block of Tantalum
-appliedenergistics2:facade:0, Cable Facade - Block of Thorium
-appliedenergistics2:facade:0, Cable Facade - Block of Pyrope
-appliedenergistics2:facade:0, Cable Facade - Block of Rock Salt
-appliedenergistics2:facade:0, Cable Facade - Block of Ruridit
-appliedenergistics2:facade:0, Cable Facade - Block of Ruby
-appliedenergistics2:facade:0, Cable Facade - Block of Salt
-appliedenergistics2:facade:0, Cable Facade - Block of Sapphire
-appliedenergistics2:facade:0, Cable Facade - Block of Sodalite
-appliedenergistics2:facade:0, Cable Facade - Block of Coke
+appliedenergistics2:facade:0, Cable Facade - Block of Soldering Alloy
+appliedenergistics2:facade:0, Cable Facade - Block of Spessartine
+appliedenergistics2:facade:0, Cable Facade - Block of Stainless Steel
+appliedenergistics2:facade:0, Cable Facade - Block of Steel
+appliedenergistics2:facade:0, Cable Facade - Block of Tin Alloy
+appliedenergistics2:facade:0, Cable Facade - Block of Topaz
+appliedenergistics2:facade:0, Cable Facade - Block of Ultimet
+appliedenergistics2:facade:0, Cable Facade - Block of Uvarovite
+appliedenergistics2:facade:0, Cable Facade - Block of Vanadium-Gallium
+appliedenergistics2:facade:0, Cable Facade - Block of Wrought Iron
+appliedenergistics2:facade:0, Cable Facade - Block of Aluminium
+appliedenergistics2:facade:0, Cable Facade - Block of Americium
+appliedenergistics2:facade:0, Cable Facade - Block of Antimony
+appliedenergistics2:facade:0, Cable Facade - Block of Beryllium
+appliedenergistics2:facade:0, Cable Facade - Block of Bismuth
+appliedenergistics2:facade:0, Cable Facade - Block of Caesium
 appliedenergistics2:facade:0, Cable Facade - Block of Silicone Rubber
 appliedenergistics2:facade:0, Cable Facade - Block of Styrene-Butadiene Rubber
 appliedenergistics2:facade:0, Cable Facade - Block of Fiber-Reinforced Epoxy Resin
 appliedenergistics2:facade:0, Cable Facade - Block of Polyvinyl Chloride (PVC)
-appliedenergistics2:facade:0, Cable Facade - Block of Red Garnet
-appliedenergistics2:facade:0, Cable Facade - Block of Yellow Garnet
-appliedenergistics2:facade:0, Cable Facade - Block of Monazite
-appliedenergistics2:facade:0, Cable Facade - Block of Yttrium Barium Cuprate
-appliedenergistics2:facade:0, Cable Facade - Block of Quartzite
-appliedenergistics2:facade:0, Cable Facade - Block of Graphene
-appliedenergistics2:facade:0, Cable Facade - Block of Osmiridium
-appliedenergistics2:facade:0, Cable Facade - Block of Gallium Arsenide
 appliedenergistics2:facade:0, Cable Facade - Block of Electrical Steel
 appliedenergistics2:facade:0, Cable Facade - Block of Energetic Alloy
 appliedenergistics2:facade:0, Cable Facade - Block of Vibrant Alloy
@@ -6411,22 +6409,25 @@ appliedenergistics2:facade:0, Cable Facade - Block of End Steel
 appliedenergistics2:facade:0, Cable Facade - Block of Iron Alloy
 appliedenergistics2:facade:0, Cable Facade - Block of Crude Steel
 appliedenergistics2:facade:0, Cable Facade - Block of Crystalline Alloy
-appliedenergistics2:facade:0, Cable Facade - Block of Soldering Alloy
-appliedenergistics2:facade:0, Cable Facade - Block of Spessartine
-appliedenergistics2:facade:0, Cable Facade - Block of Stainless Steel
-appliedenergistics2:facade:0, Cable Facade - Block of Steel
-appliedenergistics2:facade:0, Cable Facade - Block of Tin Alloy
-appliedenergistics2:facade:0, Cable Facade - Block of Topaz
-appliedenergistics2:facade:0, Cable Facade - Block of Ultimet
-appliedenergistics2:facade:0, Cable Facade - Block of Uvarovite
-appliedenergistics2:facade:0, Cable Facade - Block of Vanadium-Gallium
-appliedenergistics2:facade:0, Cable Facade - Block of Wrought Iron
+appliedenergistics2:facade:0, Cable Facade - Block of Almandine
+appliedenergistics2:facade:0, Cable Facade - Block of Andradite
+appliedenergistics2:facade:0, Cable Facade - Block of Annealed Copper
 appliedenergistics2:facade:0, Cable Facade - Block of Platinum
 appliedenergistics2:facade:0, Cable Facade - Block of Plutonium 239
 appliedenergistics2:facade:0, Cable Facade - Block of Plutonium 241
 appliedenergistics2:facade:0, Cable Facade - Block of Rhodium
 appliedenergistics2:facade:0, Cable Facade - Block of Ruthenium
 appliedenergistics2:facade:0, Cable Facade - Block of Samarium
+appliedenergistics2:facade:0, Cable Facade - Block of Europium
+appliedenergistics2:facade:0, Cable Facade - Block of Gallium
+appliedenergistics2:facade:0, Cable Facade - Block of Pyrope
+appliedenergistics2:facade:0, Cable Facade - Block of Rock Salt
+appliedenergistics2:facade:0, Cable Facade - Block of Ruridit
+appliedenergistics2:facade:0, Cable Facade - Block of Ruby
+appliedenergistics2:facade:0, Cable Facade - Block of Salt
+appliedenergistics2:facade:0, Cable Facade - Block of Sapphire
+appliedenergistics2:facade:0, Cable Facade - Block of Sodalite
+appliedenergistics2:facade:0, Cable Facade - Block of Coke
 appliedenergistics2:facade:0, Cable Facade - Block of Kanthal
 appliedenergistics2:facade:0, Cable Facade - Block of Lazurite
 appliedenergistics2:facade:0, Cable Facade - Block of Magnalium
@@ -6437,95 +6438,97 @@ appliedenergistics2:facade:0, Cable Facade - Block of Sterling Silver
 appliedenergistics2:facade:0, Cable Facade - Block of Rose Gold
 appliedenergistics2:facade:0, Cable Facade - Block of Black Bronze
 appliedenergistics2:facade:0, Cable Facade - Block of Bismuth Bronze
-appliedenergistics2:facade:0, Cable Facade - Block of Tantalum Carbide
-appliedenergistics2:facade:0, Cable Facade - Block of Molybdenum Disilicide
-appliedenergistics2:facade:0, Cable Facade - Block of HSLA Steel
-appliedenergistics2:facade:0, Cable Facade - Block of Titanium Tungsten Carbide
-appliedenergistics2:facade:0, Cable Facade - Block of Incoloy-MA956
+appliedenergistics2:facade:0, Cable Facade - Block of Yttrium Barium Cuprate
+appliedenergistics2:facade:0, Cable Facade - Block of Quartzite
+appliedenergistics2:facade:0, Cable Facade - Block of Graphene
+appliedenergistics2:facade:0, Cable Facade - Block of Osmiridium
+appliedenergistics2:facade:0, Cable Facade - Block of Gallium Arsenide
+appliedenergistics2:facade:0, Cable Facade - Block of Ruthenium Trinium Americium Neutronate
+appliedenergistics2:facade:0, Cable Facade - Block of Silicon
+appliedenergistics2:facade:0, Cable Facade - Block of Silver
+appliedenergistics2:facade:0, Cable Facade - Block of Tantalum
+appliedenergistics2:facade:0, Cable Facade - Block of Thorium
+appliedenergistics2:facade:0, Cable Facade - Block of Rubber
 appliedenergistics2:facade:0, Cable Facade - Block of Magnetic Steel
 appliedenergistics2:facade:0, Cable Facade - Block of Vanadiumsteel
 appliedenergistics2:facade:0, Cable Facade - Block of Potin
 appliedenergistics2:facade:0, Cable Facade - Block of Borosilicate Glass
 appliedenergistics2:facade:0, Cable Facade - Block of Naquadah Alloy
-appliedenergistics2:facade:0, Cable Facade - Block of Europium
-appliedenergistics2:facade:0, Cable Facade - Block of Gallium
-appliedenergistics2:facade:0, Cable Facade - Block of Cupronickel
-appliedenergistics2:facade:0, Cable Facade - Block of Electrum
-appliedenergistics2:facade:0, Cable Facade - Block of Green Sapphire
-appliedenergistics2:facade:0, Cable Facade - Block of Grossular
-appliedenergistics2:facade:0, Cable Facade - Block of Rutile
-appliedenergistics2:facade:0, Cable Facade - Block of Invar
-appliedenergistics2:facade:0, Cable Facade - Block of Aluminium
-appliedenergistics2:facade:0, Cable Facade - Block of Americium
-appliedenergistics2:facade:0, Cable Facade - Block of Antimony
-appliedenergistics2:facade:0, Cable Facade - Block of Beryllium
-appliedenergistics2:facade:0, Cable Facade - Block of Bismuth
-appliedenergistics2:facade:0, Cable Facade - Block of Caesium
 appliedenergistics2:facade:0, Cable Facade - Block of HSS-G
 appliedenergistics2:facade:0, Cable Facade - Block of Red Alloy
 appliedenergistics2:facade:0, Cable Facade - Block of HSS-E
 appliedenergistics2:facade:0, Cable Facade - Block of HSS-S
 appliedenergistics2:facade:0, Cable Facade - Block of Blue Alloy
+appliedenergistics2:facade:0, Cable Facade - Block of Indium Gallium Phosphide
+appliedenergistics2:facade:0, Cable Facade - Block of Nickel Zinc Ferrite
+appliedenergistics2:facade:0, Cable Facade - Block of Realgar
+appliedenergistics2:facade:0, Cable Facade - Block of Olivine
+appliedenergistics2:facade:0, Cable Facade - Block of Opal
+appliedenergistics2:facade:0, Cable Facade - Block of Amethyst
+appliedenergistics2:facade:0, Cable Facade - Block of Apatite
+appliedenergistics2:facade:0, Cable Facade - Block of Black Steel
+appliedenergistics2:facade:0, Cable Facade - Block of Damascus Steel
+appliedenergistics2:facade:0, Cable Facade - Block of Tungstensteel
+appliedenergistics2:facade:0, Cable Facade - Block of Cobalt Brass
+appliedenergistics2:facade:0, Cable Facade - Block of Tritanium
+appliedenergistics2:facade:0, Cable Facade - Block of Duranium
+appliedenergistics2:facade:0, Cable Facade - Block of Trinium
+appliedenergistics2:facade:0, Cable Facade - Block of Certus Quartz
+appliedenergistics2:facade:0, Cable Facade - Block of Endereye
+appliedenergistics2:facade:0, Cable Facade - Block of Red Steel
+appliedenergistics2:facade:0, Cable Facade - Block of Blue Steel
+appliedenergistics2:facade:0, Cable Facade - Block of Melodic Alloy
+appliedenergistics2:facade:0, Cable Facade - Block of Stellar Alloy
+appliedenergistics2:facade:0, Cable Facade - Block of Crystalline Pink Slime
+appliedenergistics2:facade:0, Cable Facade - Block of Energetic Silver
+appliedenergistics2:facade:0, Cable Facade - Block of Vivid Alloy
 appliedenergistics2:facade:0, Cable Facade - Block of Indium
 appliedenergistics2:facade:0, Cable Facade - Block of Iridium
 appliedenergistics2:facade:0, Cable Facade - Block of Lead
 appliedenergistics2:facade:0, Cable Facade - Block of Manganese
-appliedenergistics2:facade:0, Cable Facade - Block of Endereye
-appliedenergistics2:facade:0, Cable Facade - Block of Red Steel
-appliedenergistics2:facade:0, Cable Facade - Block of Blue Steel
 appliedenergistics2:facade:0, Cable Facade - Block of Flint
 appliedenergistics2:facade:0, Cable Facade - Block of Rhodium Plated Palladium
-appliedenergistics2:facade:0, Cable Facade - Block of Stellite-100
-appliedenergistics2:facade:0, Cable Facade - Block of Watertight Steel
-appliedenergistics2:facade:0, Cable Facade - Block of Maraging Steel 300
-appliedenergistics2:facade:0, Cable Facade - Block of Hastelloy-C276
-appliedenergistics2:facade:0, Cable Facade - Block of Hastelloy-X
-appliedenergistics2:facade:0, Cable Facade - Block of Trinaquadalloy
-appliedenergistics2:facade:0, Cable Facade - Block of Zeron-100
-appliedenergistics2:facade:0, Cable Facade - Block of Titanium Carbide
-appliedenergistics2:facade:0, Cable Facade - Block of Almandine
-appliedenergistics2:facade:0, Cable Facade - Block of Andradite
-appliedenergistics2:facade:0, Cable Facade - Block of Annealed Copper
-appliedenergistics2:facade:0, Cable Facade - Block of Tritanium
-appliedenergistics2:facade:0, Cable Facade - Block of Duranium
-appliedenergistics2:facade:0, Cable Facade - Block of Trinium
-appliedenergistics2:facade:0, Cable Facade - Block of Indium Gallium Phosphide
-appliedenergistics2:facade:0, Cable Facade - Block of Nickel Zinc Ferrite
-appliedenergistics2:facade:0, Cable Facade - Block of Realgar
-appliedenergistics2:facade:0, Cable Facade - Block of Rubber
+appliedenergistics2:facade:0, Cable Facade - Block of Malachite
+appliedenergistics2:facade:0, Cable Facade - Block of Magnetic Iron
+appliedenergistics2:facade:0, Cable Facade - Block of Tungstencarbide
 appliedenergistics2:facade:0, Cable Facade - Block of Mince Meat
-appliedenergistics2:facade:0, Cable Facade - Block of Certus Quartz
-appliedenergistics2:facade:0, Cable Facade - Block of Ruthenium Trinium Americium Neutronate
+appliedenergistics2:facade:0, Cable Facade - Block of Red Garnet
+appliedenergistics2:facade:0, Cable Facade - Block of Yellow Garnet
+appliedenergistics2:facade:0, Cable Facade - Block of Monazite
+appliedenergistics2:facade:0, Cable Facade - Block of Chrome
+appliedenergistics2:facade:0, Cable Facade - Block of Cobalt
+appliedenergistics2:facade:0, Cable Facade - Block of Copper
+appliedenergistics2:facade:0, Cable Facade - Block of Darmstadtium
 appliedenergistics2:facade:0, Cable Facade - Block of Nether Star
+appliedenergistics2:facade:0, Cable Facade - Brass Frame Box
+appliedenergistics2:facade:0, Cable Facade - Bronze Frame Box
+appliedenergistics2:facade:0, Cable Facade - Aluminium Frame Box
+appliedenergistics2:facade:0, Cable Facade - HSLA Steel Frame Box
+appliedenergistics2:facade:0, Cable Facade - Incoloy-MA956 Frame Box
+appliedenergistics2:facade:0, Cable Facade - Blue Steel Frame Box
+appliedenergistics2:facade:0, Cable Facade - Titanium Frame Box
+appliedenergistics2:facade:0, Cable Facade - Tungsten Frame Box
+appliedenergistics2:facade:0, Cable Facade - Neutronium Frame Box
+appliedenergistics2:facade:0, Cable Facade - Europium Frame Box
+appliedenergistics2:facade:0, Cable Facade - Bismuth Bronze Frame Box
 appliedenergistics2:facade:0, Cable Facade - Stainless Steel Frame Box
 appliedenergistics2:facade:0, Cable Facade - Steel Frame Box
-appliedenergistics2:facade:0, Cable Facade - Tungstencarbide Frame Box
-appliedenergistics2:facade:0, Cable Facade - Polytetrafluoroethylene (PTFE) Frame Box
 appliedenergistics2:facade:0, Cable Facade - Treated Wood Frame Box
-appliedenergistics2:facade:0, Cable Facade - Blue Steel Frame Box
+appliedenergistics2:facade:0, Cable Facade - Iron Frame Box
+appliedenergistics2:facade:0, Cable Facade - Naquadah Alloy Frame Box
 appliedenergistics2:facade:0, Cable Facade - HSS-G Frame Box
 appliedenergistics2:facade:0, Cable Facade - HSS-E Frame Box
 appliedenergistics2:facade:0, Cable Facade - HSS-S Frame Box
-appliedenergistics2:facade:0, Cable Facade - Naquadah Alloy Frame Box
-appliedenergistics2:facade:0, Cable Facade - HSLA Steel Frame Box
-appliedenergistics2:facade:0, Cable Facade - Incoloy-MA956 Frame Box
 appliedenergistics2:facade:0, Cable Facade - Watertight Steel Frame Box
 appliedenergistics2:facade:0, Cable Facade - Maraging Steel 300 Frame Box
 appliedenergistics2:facade:0, Cable Facade - Hastelloy-C276 Frame Box
 appliedenergistics2:facade:0, Cable Facade - Hastelloy-X Frame Box
+appliedenergistics2:facade:0, Cable Facade - Polytetrafluoroethylene (PTFE) Frame Box
 appliedenergistics2:facade:0, Cable Facade - Tungstensteel Frame Box
-appliedenergistics2:facade:0, Cable Facade - Europium Frame Box
-appliedenergistics2:facade:0, Cable Facade - Brass Frame Box
-appliedenergistics2:facade:0, Cable Facade - Bronze Frame Box
-appliedenergistics2:facade:0, Cable Facade - Bismuth Bronze Frame Box
-appliedenergistics2:facade:0, Cable Facade - Titanium Frame Box
-appliedenergistics2:facade:0, Cable Facade - Tungsten Frame Box
-appliedenergistics2:facade:0, Cable Facade - Neutronium Frame Box
 appliedenergistics2:facade:0, Cable Facade - Invar Frame Box
-appliedenergistics2:facade:0, Cable Facade - Iron Frame Box
+appliedenergistics2:facade:0, Cable Facade - Tungstencarbide Frame Box
 appliedenergistics2:facade:0, Cable Facade - Tritanium Frame Box
 appliedenergistics2:facade:0, Cable Facade - Wood Frame Box
-appliedenergistics2:facade:0, Cable Facade - Aluminium Frame Box
 appliedenergistics2:facade:0, Cable Facade - Crushing Wheels
 appliedenergistics2:facade:0, Cable Facade - Slicing Blades
 appliedenergistics2:facade:0, Cable Facade - Electrolytic Cell
@@ -7981,27 +7984,6 @@ chisel:chisel_iron, Chisel
 chisel:chisel_diamond, Diamond Chisel
 chisel:chisel_hitech, iChisel
 chisel:offsettool, Ender Offset Wand
-storagedrawers:upgrade_template, Upgrade Template
-storagedrawers:upgrade_storage:0, Storage Upgrade (I)
-storagedrawers:upgrade_storage:1, Storage Upgrade (II)
-storagedrawers:upgrade_storage:2, Storage Upgrade (III)
-storagedrawers:upgrade_storage:3, Storage Upgrade (IV)
-storagedrawers:upgrade_storage:4, Storage Upgrade (V)
-storagedrawers:upgrade_one_stack, Storage Downgrade
-storagedrawers:upgrade_status:0, Status Upgrade (I)
-storagedrawers:upgrade_status:1, Status Upgrade (II)
-storagedrawers:upgrade_void, Void Upgrade
-storagedrawers:upgrade_conversion, Conversion Upgrade
-storagedrawers:upgrade_creative:0, Creative Storage Upgrade
-storagedrawers:upgrade_creative:1, Creative Vending Upgrade
-storagedrawers:upgrade_redstone:0, Redstone Upgrade
-storagedrawers:upgrade_redstone:1, Redstone Max Upgrade
-storagedrawers:upgrade_redstone:2, Redstone Min Upgrade
-storagedrawers:drawer_key, Drawer Key
-storagedrawers:shroud_key, Concealment Key
-storagedrawers:personal_key, Personal Key
-storagedrawers:quantify_key, Quantify Key
-storagedrawers:tape, Packing Tape
 storagedrawers:basicdrawers:0, Basic Drawer
 storagedrawers:basicdrawers:0, Basic Drawer
 storagedrawers:basicdrawers:0, Basic Drawer
@@ -8052,6 +8034,27 @@ storagedrawers:customdrawers:2, Framed Drawers 2x2
 storagedrawers:customdrawers:3, Framed Half Drawers 1x2
 storagedrawers:customdrawers:4, Framed Half Drawers 2x2
 storagedrawers:customtrim, Framed Trim
+storagedrawers:upgrade_template, Upgrade Template
+storagedrawers:upgrade_storage:0, Storage Upgrade (I)
+storagedrawers:upgrade_storage:1, Storage Upgrade (II)
+storagedrawers:upgrade_storage:2, Storage Upgrade (III)
+storagedrawers:upgrade_storage:3, Storage Upgrade (IV)
+storagedrawers:upgrade_storage:4, Storage Upgrade (V)
+storagedrawers:upgrade_one_stack, Storage Downgrade
+storagedrawers:upgrade_status:0, Status Upgrade (I)
+storagedrawers:upgrade_status:1, Status Upgrade (II)
+storagedrawers:upgrade_void, Void Upgrade
+storagedrawers:upgrade_conversion, Conversion Upgrade
+storagedrawers:upgrade_creative:0, Creative Storage Upgrade
+storagedrawers:upgrade_creative:1, Creative Vending Upgrade
+storagedrawers:upgrade_redstone:0, Redstone Upgrade
+storagedrawers:upgrade_redstone:1, Redstone Max Upgrade
+storagedrawers:upgrade_redstone:2, Redstone Min Upgrade
+storagedrawers:drawer_key, Drawer Key
+storagedrawers:shroud_key, Concealment Key
+storagedrawers:personal_key, Personal Key
+storagedrawers:quantify_key, Quantify Key
+storagedrawers:tape, Packing Tape
 compactdrawers:compact_drawer_2by1, Compacting Drawers 1x2
 compactdrawers:compact_drawer_2by1_half, Compacting Drawers 1x2 Half
 compactdrawers:compact_drawer_half, Compacting Drawers Half
@@ -9413,142 +9416,142 @@ gregtech:fluid_pipe_nonuple:396, Nonuple Tungstencarbide Fluid Pipe
 gregtech:fluid_pipe_nonuple:2013, Nonuple Tungstensteel Fluid Pipe
 gregtech:fluid_pipe_nonuple:2036, Nonuple Vanadiumsteel Fluid Pipe
 gregtech:fluid_pipe_nonuple:335, Nonuple Wrought Iron Fluid Pipe
-gregtech:item_pipe_small:302, Small Black Bronze Item Pipe
-gregtech:item_pipe_small:69, Small Nickel Item Pipe
 gregtech:item_pipe_small:274, Small Cupronickel Item Pipe
 gregtech:item_pipe_small:259, Small Brass Item Pipe
-gregtech:item_pipe_small:112, Small Tin Item Pipe
+gregtech:item_pipe_small:300, Small Sterling Silver Item Pipe
 gregtech:item_pipe_small:277, Small Electrum Item Pipe
-gregtech:item_pipe_small:301, Small Rose Gold Item Pipe
+gregtech:item_pipe_small:69, Small Nickel Item Pipe
+gregtech:item_pipe_small:2014, Small Cobalt Brass Item Pipe
+gregtech:item_pipe_small:112, Small Tin Item Pipe
+gregtech:item_pipe_small:23, Small Cobalt Item Pipe
+gregtech:item_pipe_small:3, Small Americium Item Pipe
+gregtech:item_pipe_small:75, Small Osmium Item Pipe
 gregtech:item_pipe_small:1007, Small Polyvinyl Chloride (PVC) Item Pipe
 gregtech:item_pipe_small:80, Small Platinum Item Pipe
-gregtech:item_pipe_small:331, Small Ultimet Item Pipe
-gregtech:item_pipe_small:3, Small Americium Item Pipe
 gregtech:item_pipe_small:290, Small Magnalium Item Pipe
-gregtech:item_pipe_small:75, Small Osmium Item Pipe
 gregtech:item_pipe_small:344, Small Osmiridium Item Pipe
-gregtech:item_pipe_small:2014, Small Cobalt Brass Item Pipe
-gregtech:item_pipe_small:300, Small Sterling Silver Item Pipe
-gregtech:item_pipe_small:23, Small Cobalt Item Pipe
-gregtech:item_pipe_normal:302, Black Bronze Item Pipe
-gregtech:item_pipe_normal:69, Nickel Item Pipe
+gregtech:item_pipe_small:331, Small Ultimet Item Pipe
+gregtech:item_pipe_small:301, Small Rose Gold Item Pipe
+gregtech:item_pipe_small:302, Small Black Bronze Item Pipe
 gregtech:item_pipe_normal:274, Cupronickel Item Pipe
 gregtech:item_pipe_normal:259, Brass Item Pipe
-gregtech:item_pipe_normal:112, Tin Item Pipe
+gregtech:item_pipe_normal:300, Sterling Silver Item Pipe
 gregtech:item_pipe_normal:277, Electrum Item Pipe
-gregtech:item_pipe_normal:301, Rose Gold Item Pipe
+gregtech:item_pipe_normal:69, Nickel Item Pipe
+gregtech:item_pipe_normal:2014, Cobalt Brass Item Pipe
+gregtech:item_pipe_normal:112, Tin Item Pipe
+gregtech:item_pipe_normal:23, Cobalt Item Pipe
+gregtech:item_pipe_normal:3, Americium Item Pipe
+gregtech:item_pipe_normal:75, Osmium Item Pipe
 gregtech:item_pipe_normal:1007, Polyvinyl Chloride (PVC) Item Pipe
 gregtech:item_pipe_normal:80, Platinum Item Pipe
-gregtech:item_pipe_normal:331, Ultimet Item Pipe
-gregtech:item_pipe_normal:3, Americium Item Pipe
 gregtech:item_pipe_normal:290, Magnalium Item Pipe
-gregtech:item_pipe_normal:75, Osmium Item Pipe
 gregtech:item_pipe_normal:344, Osmiridium Item Pipe
-gregtech:item_pipe_normal:2014, Cobalt Brass Item Pipe
-gregtech:item_pipe_normal:300, Sterling Silver Item Pipe
-gregtech:item_pipe_normal:23, Cobalt Item Pipe
-gregtech:item_pipe_large:302, Large Black Bronze Item Pipe
-gregtech:item_pipe_large:69, Large Nickel Item Pipe
+gregtech:item_pipe_normal:331, Ultimet Item Pipe
+gregtech:item_pipe_normal:301, Rose Gold Item Pipe
+gregtech:item_pipe_normal:302, Black Bronze Item Pipe
 gregtech:item_pipe_large:274, Large Cupronickel Item Pipe
 gregtech:item_pipe_large:259, Large Brass Item Pipe
-gregtech:item_pipe_large:112, Large Tin Item Pipe
+gregtech:item_pipe_large:300, Large Sterling Silver Item Pipe
 gregtech:item_pipe_large:277, Large Electrum Item Pipe
-gregtech:item_pipe_large:301, Large Rose Gold Item Pipe
+gregtech:item_pipe_large:69, Large Nickel Item Pipe
+gregtech:item_pipe_large:2014, Large Cobalt Brass Item Pipe
+gregtech:item_pipe_large:112, Large Tin Item Pipe
+gregtech:item_pipe_large:23, Large Cobalt Item Pipe
+gregtech:item_pipe_large:3, Large Americium Item Pipe
+gregtech:item_pipe_large:75, Large Osmium Item Pipe
 gregtech:item_pipe_large:1007, Large Polyvinyl Chloride (PVC) Item Pipe
 gregtech:item_pipe_large:80, Large Platinum Item Pipe
-gregtech:item_pipe_large:331, Large Ultimet Item Pipe
-gregtech:item_pipe_large:3, Large Americium Item Pipe
 gregtech:item_pipe_large:290, Large Magnalium Item Pipe
-gregtech:item_pipe_large:75, Large Osmium Item Pipe
 gregtech:item_pipe_large:344, Large Osmiridium Item Pipe
-gregtech:item_pipe_large:2014, Large Cobalt Brass Item Pipe
-gregtech:item_pipe_large:300, Large Sterling Silver Item Pipe
-gregtech:item_pipe_large:23, Large Cobalt Item Pipe
-gregtech:item_pipe_huge:302, Huge Black Bronze Item Pipe
-gregtech:item_pipe_huge:69, Huge Nickel Item Pipe
+gregtech:item_pipe_large:331, Large Ultimet Item Pipe
+gregtech:item_pipe_large:301, Large Rose Gold Item Pipe
+gregtech:item_pipe_large:302, Large Black Bronze Item Pipe
 gregtech:item_pipe_huge:274, Huge Cupronickel Item Pipe
 gregtech:item_pipe_huge:259, Huge Brass Item Pipe
-gregtech:item_pipe_huge:112, Huge Tin Item Pipe
+gregtech:item_pipe_huge:300, Huge Sterling Silver Item Pipe
 gregtech:item_pipe_huge:277, Huge Electrum Item Pipe
-gregtech:item_pipe_huge:301, Huge Rose Gold Item Pipe
+gregtech:item_pipe_huge:69, Huge Nickel Item Pipe
+gregtech:item_pipe_huge:2014, Huge Cobalt Brass Item Pipe
+gregtech:item_pipe_huge:112, Huge Tin Item Pipe
+gregtech:item_pipe_huge:23, Huge Cobalt Item Pipe
+gregtech:item_pipe_huge:3, Huge Americium Item Pipe
+gregtech:item_pipe_huge:75, Huge Osmium Item Pipe
 gregtech:item_pipe_huge:1007, Huge Polyvinyl Chloride (PVC) Item Pipe
 gregtech:item_pipe_huge:80, Huge Platinum Item Pipe
-gregtech:item_pipe_huge:331, Huge Ultimet Item Pipe
-gregtech:item_pipe_huge:3, Huge Americium Item Pipe
 gregtech:item_pipe_huge:290, Huge Magnalium Item Pipe
-gregtech:item_pipe_huge:75, Huge Osmium Item Pipe
 gregtech:item_pipe_huge:344, Huge Osmiridium Item Pipe
-gregtech:item_pipe_huge:2014, Huge Cobalt Brass Item Pipe
-gregtech:item_pipe_huge:300, Huge Sterling Silver Item Pipe
-gregtech:item_pipe_huge:23, Huge Cobalt Item Pipe
-gregtech:item_pipe_small_restrictive:302, Small Restrictive Black Bronze Item Pipe
-gregtech:item_pipe_small_restrictive:69, Small Restrictive Nickel Item Pipe
+gregtech:item_pipe_huge:331, Huge Ultimet Item Pipe
+gregtech:item_pipe_huge:301, Huge Rose Gold Item Pipe
+gregtech:item_pipe_huge:302, Huge Black Bronze Item Pipe
 gregtech:item_pipe_small_restrictive:274, Small Restrictive Cupronickel Item Pipe
 gregtech:item_pipe_small_restrictive:259, Small Restrictive Brass Item Pipe
-gregtech:item_pipe_small_restrictive:112, Small Restrictive Tin Item Pipe
+gregtech:item_pipe_small_restrictive:300, Small Restrictive Sterling Silver Item Pipe
 gregtech:item_pipe_small_restrictive:277, Small Restrictive Electrum Item Pipe
-gregtech:item_pipe_small_restrictive:301, Small Restrictive Rose Gold Item Pipe
+gregtech:item_pipe_small_restrictive:69, Small Restrictive Nickel Item Pipe
+gregtech:item_pipe_small_restrictive:2014, Small Restrictive Cobalt Brass Item Pipe
+gregtech:item_pipe_small_restrictive:112, Small Restrictive Tin Item Pipe
+gregtech:item_pipe_small_restrictive:23, Small Restrictive Cobalt Item Pipe
+gregtech:item_pipe_small_restrictive:3, Small Restrictive Americium Item Pipe
+gregtech:item_pipe_small_restrictive:75, Small Restrictive Osmium Item Pipe
 gregtech:item_pipe_small_restrictive:1007, Small Restrictive Polyvinyl Chloride (PVC) Item Pipe
 gregtech:item_pipe_small_restrictive:80, Small Restrictive Platinum Item Pipe
-gregtech:item_pipe_small_restrictive:331, Small Restrictive Ultimet Item Pipe
-gregtech:item_pipe_small_restrictive:3, Small Restrictive Americium Item Pipe
 gregtech:item_pipe_small_restrictive:290, Small Restrictive Magnalium Item Pipe
-gregtech:item_pipe_small_restrictive:75, Small Restrictive Osmium Item Pipe
 gregtech:item_pipe_small_restrictive:344, Small Restrictive Osmiridium Item Pipe
-gregtech:item_pipe_small_restrictive:2014, Small Restrictive Cobalt Brass Item Pipe
-gregtech:item_pipe_small_restrictive:300, Small Restrictive Sterling Silver Item Pipe
-gregtech:item_pipe_small_restrictive:23, Small Restrictive Cobalt Item Pipe
-gregtech:item_pipe_normal_restrictive:302, Restrictive Black Bronze Item Pipe
-gregtech:item_pipe_normal_restrictive:69, Restrictive Nickel Item Pipe
+gregtech:item_pipe_small_restrictive:331, Small Restrictive Ultimet Item Pipe
+gregtech:item_pipe_small_restrictive:301, Small Restrictive Rose Gold Item Pipe
+gregtech:item_pipe_small_restrictive:302, Small Restrictive Black Bronze Item Pipe
 gregtech:item_pipe_normal_restrictive:274, Restrictive Cupronickel Item Pipe
 gregtech:item_pipe_normal_restrictive:259, Restrictive Brass Item Pipe
-gregtech:item_pipe_normal_restrictive:112, Restrictive Tin Item Pipe
+gregtech:item_pipe_normal_restrictive:300, Restrictive Sterling Silver Item Pipe
 gregtech:item_pipe_normal_restrictive:277, Restrictive Electrum Item Pipe
-gregtech:item_pipe_normal_restrictive:301, Restrictive Rose Gold Item Pipe
+gregtech:item_pipe_normal_restrictive:69, Restrictive Nickel Item Pipe
+gregtech:item_pipe_normal_restrictive:2014, Restrictive Cobalt Brass Item Pipe
+gregtech:item_pipe_normal_restrictive:112, Restrictive Tin Item Pipe
+gregtech:item_pipe_normal_restrictive:23, Restrictive Cobalt Item Pipe
+gregtech:item_pipe_normal_restrictive:3, Restrictive Americium Item Pipe
+gregtech:item_pipe_normal_restrictive:75, Restrictive Osmium Item Pipe
 gregtech:item_pipe_normal_restrictive:1007, Restrictive Polyvinyl Chloride (PVC) Item Pipe
 gregtech:item_pipe_normal_restrictive:80, Restrictive Platinum Item Pipe
-gregtech:item_pipe_normal_restrictive:331, Restrictive Ultimet Item Pipe
-gregtech:item_pipe_normal_restrictive:3, Restrictive Americium Item Pipe
 gregtech:item_pipe_normal_restrictive:290, Restrictive Magnalium Item Pipe
-gregtech:item_pipe_normal_restrictive:75, Restrictive Osmium Item Pipe
 gregtech:item_pipe_normal_restrictive:344, Restrictive Osmiridium Item Pipe
-gregtech:item_pipe_normal_restrictive:2014, Restrictive Cobalt Brass Item Pipe
-gregtech:item_pipe_normal_restrictive:300, Restrictive Sterling Silver Item Pipe
-gregtech:item_pipe_normal_restrictive:23, Restrictive Cobalt Item Pipe
-gregtech:item_pipe_large_restrictive:302, Large Restrictive Black Bronze Item Pipe
-gregtech:item_pipe_large_restrictive:69, Large Restrictive Nickel Item Pipe
+gregtech:item_pipe_normal_restrictive:331, Restrictive Ultimet Item Pipe
+gregtech:item_pipe_normal_restrictive:301, Restrictive Rose Gold Item Pipe
+gregtech:item_pipe_normal_restrictive:302, Restrictive Black Bronze Item Pipe
 gregtech:item_pipe_large_restrictive:274, Large Restrictive Cupronickel Item Pipe
 gregtech:item_pipe_large_restrictive:259, Large Restrictive Brass Item Pipe
-gregtech:item_pipe_large_restrictive:112, Large Restrictive Tin Item Pipe
+gregtech:item_pipe_large_restrictive:300, Large Restrictive Sterling Silver Item Pipe
 gregtech:item_pipe_large_restrictive:277, Large Restrictive Electrum Item Pipe
-gregtech:item_pipe_large_restrictive:301, Large Restrictive Rose Gold Item Pipe
+gregtech:item_pipe_large_restrictive:69, Large Restrictive Nickel Item Pipe
+gregtech:item_pipe_large_restrictive:2014, Large Restrictive Cobalt Brass Item Pipe
+gregtech:item_pipe_large_restrictive:112, Large Restrictive Tin Item Pipe
+gregtech:item_pipe_large_restrictive:23, Large Restrictive Cobalt Item Pipe
+gregtech:item_pipe_large_restrictive:3, Large Restrictive Americium Item Pipe
+gregtech:item_pipe_large_restrictive:75, Large Restrictive Osmium Item Pipe
 gregtech:item_pipe_large_restrictive:1007, Large Restrictive Polyvinyl Chloride (PVC) Item Pipe
 gregtech:item_pipe_large_restrictive:80, Large Restrictive Platinum Item Pipe
-gregtech:item_pipe_large_restrictive:331, Large Restrictive Ultimet Item Pipe
-gregtech:item_pipe_large_restrictive:3, Large Restrictive Americium Item Pipe
 gregtech:item_pipe_large_restrictive:290, Large Restrictive Magnalium Item Pipe
-gregtech:item_pipe_large_restrictive:75, Large Restrictive Osmium Item Pipe
 gregtech:item_pipe_large_restrictive:344, Large Restrictive Osmiridium Item Pipe
-gregtech:item_pipe_large_restrictive:2014, Large Restrictive Cobalt Brass Item Pipe
-gregtech:item_pipe_large_restrictive:300, Large Restrictive Sterling Silver Item Pipe
-gregtech:item_pipe_large_restrictive:23, Large Restrictive Cobalt Item Pipe
-gregtech:item_pipe_huge_restrictive:302, Huge Restrictive Black Bronze Item Pipe
-gregtech:item_pipe_huge_restrictive:69, Huge Restrictive Nickel Item Pipe
+gregtech:item_pipe_large_restrictive:331, Large Restrictive Ultimet Item Pipe
+gregtech:item_pipe_large_restrictive:301, Large Restrictive Rose Gold Item Pipe
+gregtech:item_pipe_large_restrictive:302, Large Restrictive Black Bronze Item Pipe
 gregtech:item_pipe_huge_restrictive:274, Huge Restrictive Cupronickel Item Pipe
 gregtech:item_pipe_huge_restrictive:259, Huge Restrictive Brass Item Pipe
-gregtech:item_pipe_huge_restrictive:112, Huge Restrictive Tin Item Pipe
+gregtech:item_pipe_huge_restrictive:300, Huge Restrictive Sterling Silver Item Pipe
 gregtech:item_pipe_huge_restrictive:277, Huge Restrictive Electrum Item Pipe
-gregtech:item_pipe_huge_restrictive:301, Huge Restrictive Rose Gold Item Pipe
+gregtech:item_pipe_huge_restrictive:69, Huge Restrictive Nickel Item Pipe
+gregtech:item_pipe_huge_restrictive:2014, Huge Restrictive Cobalt Brass Item Pipe
+gregtech:item_pipe_huge_restrictive:112, Huge Restrictive Tin Item Pipe
+gregtech:item_pipe_huge_restrictive:23, Huge Restrictive Cobalt Item Pipe
+gregtech:item_pipe_huge_restrictive:3, Huge Restrictive Americium Item Pipe
+gregtech:item_pipe_huge_restrictive:75, Huge Restrictive Osmium Item Pipe
 gregtech:item_pipe_huge_restrictive:1007, Huge Restrictive Polyvinyl Chloride (PVC) Item Pipe
 gregtech:item_pipe_huge_restrictive:80, Huge Restrictive Platinum Item Pipe
-gregtech:item_pipe_huge_restrictive:331, Huge Restrictive Ultimet Item Pipe
-gregtech:item_pipe_huge_restrictive:3, Huge Restrictive Americium Item Pipe
 gregtech:item_pipe_huge_restrictive:290, Huge Restrictive Magnalium Item Pipe
-gregtech:item_pipe_huge_restrictive:75, Huge Restrictive Osmium Item Pipe
 gregtech:item_pipe_huge_restrictive:344, Huge Restrictive Osmiridium Item Pipe
-gregtech:item_pipe_huge_restrictive:2014, Huge Restrictive Cobalt Brass Item Pipe
-gregtech:item_pipe_huge_restrictive:300, Huge Restrictive Sterling Silver Item Pipe
-gregtech:item_pipe_huge_restrictive:23, Huge Restrictive Cobalt Item Pipe
+gregtech:item_pipe_huge_restrictive:331, Huge Restrictive Ultimet Item Pipe
+gregtech:item_pipe_huge_restrictive:301, Huge Restrictive Rose Gold Item Pipe
+gregtech:item_pipe_huge_restrictive:302, Huge Restrictive Black Bronze Item Pipe
 gregtech:hermetic_casing:0, Hermetic Casing I
 gregtech:hermetic_casing:1, Hermetic Casing II
 gregtech:hermetic_casing:2, Hermetic Casing III
@@ -9736,10 +9739,26 @@ gregtech:meta_block_compressed_4:5, Block of Nickel
 gregtech:meta_block_compressed_4:7, Block of Niobium
 gregtech:meta_block_compressed_4:11, Block of Osmium
 gregtech:meta_block_compressed_4:13, Block of Palladium
-gregtech:meta_block_compressed_1:6, Block of Chrome
-gregtech:meta_block_compressed_1:7, Block of Cobalt
-gregtech:meta_block_compressed_1:9, Block of Copper
-gregtech:meta_block_compressed_1:11, Block of Darmstadtium
+gregtech:meta_block_compressed_16:0, Block of Battery Alloy
+gregtech:meta_block_compressed_16:1, Block of Blue Topaz
+gregtech:meta_block_compressed_16:3, Block of Brass
+gregtech:meta_block_compressed_16:4, Block of Bronze
+gregtech:meta_block_compressed_16:10, Block of Charcoal
+gregtech:meta_block_compressed_16:12, Block of Cinnabar
+gregtech:meta_block_compressed_187:8, Block of Stellite-100
+gregtech:meta_block_compressed_187:9, Block of Watertight Steel
+gregtech:meta_block_compressed_187:10, Block of Maraging Steel 300
+gregtech:meta_block_compressed_187:11, Block of Hastelloy-C276
+gregtech:meta_block_compressed_187:12, Block of Hastelloy-X
+gregtech:meta_block_compressed_187:13, Block of Trinaquadalloy
+gregtech:meta_block_compressed_187:14, Block of Zeron-100
+gregtech:meta_block_compressed_187:15, Block of Titanium Carbide
+gregtech:meta_block_compressed_17:2, Block of Cupronickel
+gregtech:meta_block_compressed_17:5, Block of Electrum
+gregtech:meta_block_compressed_17:9, Block of Green Sapphire
+gregtech:meta_block_compressed_17:10, Block of Grossular
+gregtech:meta_block_compressed_17:13, Block of Rutile
+gregtech:meta_block_compressed_17:15, Block of Invar
 gregtech:meta_block_compressed_26:0, Block of Enderpearl
 gregtech:meta_block_compressed_26:2, Block of Magnetic Neodymium
 gregtech:meta_block_compressed_26:7, Block of Magnetic Samarium
@@ -9751,14 +9770,11 @@ gregtech:meta_block_compressed_26:12, Block of Samarium Iron Arsenic Oxide
 gregtech:meta_block_compressed_26:13, Block of Indium Tin Barium Titanium Cuprate
 gregtech:meta_block_compressed_26:14, Block of Uranium Rhodium Dinaquadide
 gregtech:meta_block_compressed_26:15, Block of Enriched Naquadah Trinium Europium Duranide
-gregtech:meta_block_compressed_125:4, Block of Olivine
-gregtech:meta_block_compressed_125:5, Block of Opal
-gregtech:meta_block_compressed_125:6, Block of Amethyst
-gregtech:meta_block_compressed_125:10, Block of Apatite
-gregtech:meta_block_compressed_125:11, Block of Black Steel
-gregtech:meta_block_compressed_125:12, Block of Damascus Steel
-gregtech:meta_block_compressed_125:13, Block of Tungstensteel
-gregtech:meta_block_compressed_125:14, Block of Cobalt Brass
+gregtech:meta_block_compressed_188:0, Block of Tantalum Carbide
+gregtech:meta_block_compressed_188:1, Block of Molybdenum Disilicide
+gregtech:meta_block_compressed_188:12, Block of HSLA Steel
+gregtech:meta_block_compressed_188:13, Block of Titanium Tungsten Carbide
+gregtech:meta_block_compressed_188:14, Block of Incoloy-MA956
 gregtech:meta_block_compressed_7:0, Block of Tin
 gregtech:meta_block_compressed_7:1, Block of Titanium
 gregtech:meta_block_compressed_7:3, Block of Tungsten
@@ -9771,44 +9787,26 @@ gregtech:meta_block_compressed_7:12, Block of Naquadah
 gregtech:meta_block_compressed_7:13, Block of Enriched Naquadah
 gregtech:meta_block_compressed_7:14, Block of Naquadria
 gregtech:meta_block_compressed_7:15, Block of Neutronium
-gregtech:meta_block_compressed_24:1, Block of Malachite
-gregtech:meta_block_compressed_24:11, Block of Magnetic Iron
-gregtech:meta_block_compressed_24:12, Block of Tungstencarbide
-gregtech:meta_block_compressed_16:0, Block of Battery Alloy
-gregtech:meta_block_compressed_16:1, Block of Blue Topaz
-gregtech:meta_block_compressed_16:3, Block of Brass
-gregtech:meta_block_compressed_16:4, Block of Bronze
-gregtech:meta_block_compressed_16:10, Block of Charcoal
-gregtech:meta_block_compressed_16:12, Block of Cinnabar
-gregtech:meta_block_compressed_2007:0, Block of Melodic Alloy
-gregtech:meta_block_compressed_2007:1, Block of Stellar Alloy
-gregtech:meta_block_compressed_2007:2, Block of Crystalline Pink Slime
-gregtech:meta_block_compressed_2007:3, Block of Energetic Silver
-gregtech:meta_block_compressed_2007:4, Block of Vivid Alloy
-gregtech:meta_block_compressed_6:3, Block of Silicon
-gregtech:meta_block_compressed_6:4, Block of Silver
-gregtech:meta_block_compressed_6:8, Block of Tantalum
-gregtech:meta_block_compressed_6:13, Block of Thorium
-gregtech:meta_block_compressed_19:4, Block of Pyrope
-gregtech:meta_block_compressed_19:5, Block of Rock Salt
-gregtech:meta_block_compressed_19:6, Block of Ruridit
-gregtech:meta_block_compressed_19:7, Block of Ruby
-gregtech:meta_block_compressed_19:8, Block of Salt
-gregtech:meta_block_compressed_19:10, Block of Sapphire
-gregtech:meta_block_compressed_19:12, Block of Sodalite
-gregtech:meta_block_compressed_19:15, Block of Coke
+gregtech:meta_block_compressed_20:0, Block of Soldering Alloy
+gregtech:meta_block_compressed_20:1, Block of Spessartine
+gregtech:meta_block_compressed_20:3, Block of Stainless Steel
+gregtech:meta_block_compressed_20:4, Block of Steel
+gregtech:meta_block_compressed_20:8, Block of Tin Alloy
+gregtech:meta_block_compressed_20:9, Block of Topaz
+gregtech:meta_block_compressed_20:11, Block of Ultimet
+gregtech:meta_block_compressed_20:13, Block of Uvarovite
+gregtech:meta_block_compressed_20:14, Block of Vanadium-Gallium
+gregtech:meta_block_compressed_20:15, Block of Wrought Iron
+gregtech:meta_block_compressed_0:2, Block of Aluminium
+gregtech:meta_block_compressed_0:3, Block of Americium
+gregtech:meta_block_compressed_0:4, Block of Antimony
+gregtech:meta_block_compressed_0:10, Block of Beryllium
+gregtech:meta_block_compressed_0:11, Block of Bismuth
+gregtech:meta_block_compressed_0:15, Block of Caesium
 gregtech:meta_block_compressed_62:8, Block of Silicone Rubber
 gregtech:meta_block_compressed_62:12, Block of Styrene-Butadiene Rubber
 gregtech:meta_block_compressed_62:14, Block of Fiber-Reinforced Epoxy Resin
 gregtech:meta_block_compressed_62:15, Block of Polyvinyl Chloride (PVC)
-gregtech:meta_block_compressed_126:0, Block of Red Garnet
-gregtech:meta_block_compressed_126:1, Block of Yellow Garnet
-gregtech:meta_block_compressed_126:13, Block of Monazite
-gregtech:meta_block_compressed_21:2, Block of Yttrium Barium Cuprate
-gregtech:meta_block_compressed_21:4, Block of Quartzite
-gregtech:meta_block_compressed_21:6, Block of Graphene
-gregtech:meta_block_compressed_21:8, Block of Osmiridium
-gregtech:meta_block_compressed_21:15, Block of Gallium Arsenide
 gregtech:meta_block_compressed_2006:4, Block of Electrical Steel
 gregtech:meta_block_compressed_2006:5, Block of Energetic Alloy
 gregtech:meta_block_compressed_2006:6, Block of Vibrant Alloy
@@ -9821,22 +9819,25 @@ gregtech:meta_block_compressed_2006:12, Block of End Steel
 gregtech:meta_block_compressed_2006:13, Block of Iron Alloy
 gregtech:meta_block_compressed_2006:14, Block of Crude Steel
 gregtech:meta_block_compressed_2006:15, Block of Crystalline Alloy
-gregtech:meta_block_compressed_20:0, Block of Soldering Alloy
-gregtech:meta_block_compressed_20:1, Block of Spessartine
-gregtech:meta_block_compressed_20:3, Block of Stainless Steel
-gregtech:meta_block_compressed_20:4, Block of Steel
-gregtech:meta_block_compressed_20:8, Block of Tin Alloy
-gregtech:meta_block_compressed_20:9, Block of Topaz
-gregtech:meta_block_compressed_20:11, Block of Ultimet
-gregtech:meta_block_compressed_20:13, Block of Uvarovite
-gregtech:meta_block_compressed_20:14, Block of Vanadium-Gallium
-gregtech:meta_block_compressed_20:15, Block of Wrought Iron
+gregtech:meta_block_compressed_15:10, Block of Almandine
+gregtech:meta_block_compressed_15:11, Block of Andradite
+gregtech:meta_block_compressed_15:12, Block of Annealed Copper
 gregtech:meta_block_compressed_5:0, Block of Platinum
 gregtech:meta_block_compressed_5:1, Block of Plutonium 239
 gregtech:meta_block_compressed_5:2, Block of Plutonium 241
 gregtech:meta_block_compressed_5:10, Block of Rhodium
 gregtech:meta_block_compressed_5:13, Block of Ruthenium
 gregtech:meta_block_compressed_5:15, Block of Samarium
+gregtech:meta_block_compressed_2:1, Block of Europium
+gregtech:meta_block_compressed_2:7, Block of Gallium
+gregtech:meta_block_compressed_19:4, Block of Pyrope
+gregtech:meta_block_compressed_19:5, Block of Rock Salt
+gregtech:meta_block_compressed_19:6, Block of Ruridit
+gregtech:meta_block_compressed_19:7, Block of Ruby
+gregtech:meta_block_compressed_19:8, Block of Salt
+gregtech:meta_block_compressed_19:10, Block of Sapphire
+gregtech:meta_block_compressed_19:12, Block of Sodalite
+gregtech:meta_block_compressed_19:15, Block of Coke
 gregtech:meta_block_compressed_18:0, Block of Kanthal
 gregtech:meta_block_compressed_18:1, Block of Lazurite
 gregtech:meta_block_compressed_18:2, Block of Magnalium
@@ -9847,95 +9848,97 @@ gregtech:meta_block_compressed_18:12, Block of Sterling Silver
 gregtech:meta_block_compressed_18:13, Block of Rose Gold
 gregtech:meta_block_compressed_18:14, Block of Black Bronze
 gregtech:meta_block_compressed_18:15, Block of Bismuth Bronze
-gregtech:meta_block_compressed_188:0, Block of Tantalum Carbide
-gregtech:meta_block_compressed_188:1, Block of Molybdenum Disilicide
-gregtech:meta_block_compressed_188:12, Block of HSLA Steel
-gregtech:meta_block_compressed_188:13, Block of Titanium Tungsten Carbide
-gregtech:meta_block_compressed_188:14, Block of Incoloy-MA956
+gregtech:meta_block_compressed_21:2, Block of Yttrium Barium Cuprate
+gregtech:meta_block_compressed_21:4, Block of Quartzite
+gregtech:meta_block_compressed_21:6, Block of Graphene
+gregtech:meta_block_compressed_21:8, Block of Osmiridium
+gregtech:meta_block_compressed_21:15, Block of Gallium Arsenide
+gregtech:meta_block_compressed_27:0, Block of Ruthenium Trinium Americium Neutronate
+gregtech:meta_block_compressed_6:3, Block of Silicon
+gregtech:meta_block_compressed_6:4, Block of Silver
+gregtech:meta_block_compressed_6:8, Block of Tantalum
+gregtech:meta_block_compressed_6:13, Block of Thorium
+gregtech:meta_block_compressed_66:12, Block of Rubber
 gregtech:meta_block_compressed_127:3, Block of Magnetic Steel
 gregtech:meta_block_compressed_127:4, Block of Vanadiumsteel
 gregtech:meta_block_compressed_127:5, Block of Potin
 gregtech:meta_block_compressed_127:6, Block of Borosilicate Glass
 gregtech:meta_block_compressed_127:10, Block of Naquadah Alloy
-gregtech:meta_block_compressed_2:1, Block of Europium
-gregtech:meta_block_compressed_2:7, Block of Gallium
-gregtech:meta_block_compressed_17:2, Block of Cupronickel
-gregtech:meta_block_compressed_17:5, Block of Electrum
-gregtech:meta_block_compressed_17:9, Block of Green Sapphire
-gregtech:meta_block_compressed_17:10, Block of Grossular
-gregtech:meta_block_compressed_17:13, Block of Rutile
-gregtech:meta_block_compressed_17:15, Block of Invar
-gregtech:meta_block_compressed_0:2, Block of Aluminium
-gregtech:meta_block_compressed_0:3, Block of Americium
-gregtech:meta_block_compressed_0:4, Block of Antimony
-gregtech:meta_block_compressed_0:10, Block of Beryllium
-gregtech:meta_block_compressed_0:11, Block of Bismuth
-gregtech:meta_block_compressed_0:15, Block of Caesium
 gregtech:meta_block_compressed_157:4, Block of HSS-G
 gregtech:meta_block_compressed_157:5, Block of Red Alloy
 gregtech:meta_block_compressed_157:7, Block of HSS-E
 gregtech:meta_block_compressed_157:8, Block of HSS-S
 gregtech:meta_block_compressed_157:15, Block of Blue Alloy
+gregtech:meta_block_compressed_22:2, Block of Indium Gallium Phosphide
+gregtech:meta_block_compressed_22:3, Block of Nickel Zinc Ferrite
+gregtech:meta_block_compressed_22:13, Block of Realgar
+gregtech:meta_block_compressed_125:4, Block of Olivine
+gregtech:meta_block_compressed_125:5, Block of Opal
+gregtech:meta_block_compressed_125:6, Block of Amethyst
+gregtech:meta_block_compressed_125:10, Block of Apatite
+gregtech:meta_block_compressed_125:11, Block of Black Steel
+gregtech:meta_block_compressed_125:12, Block of Damascus Steel
+gregtech:meta_block_compressed_125:13, Block of Tungstensteel
+gregtech:meta_block_compressed_125:14, Block of Cobalt Brass
+gregtech:meta_block_compressed_8:0, Block of Tritanium
+gregtech:meta_block_compressed_8:1, Block of Duranium
+gregtech:meta_block_compressed_8:2, Block of Trinium
+gregtech:meta_block_compressed_13:6, Block of Certus Quartz
+gregtech:meta_block_compressed_156:12, Block of Endereye
+gregtech:meta_block_compressed_156:14, Block of Red Steel
+gregtech:meta_block_compressed_156:15, Block of Blue Steel
+gregtech:meta_block_compressed_2007:0, Block of Melodic Alloy
+gregtech:meta_block_compressed_2007:1, Block of Stellar Alloy
+gregtech:meta_block_compressed_2007:2, Block of Crystalline Pink Slime
+gregtech:meta_block_compressed_2007:3, Block of Energetic Silver
+gregtech:meta_block_compressed_2007:4, Block of Vivid Alloy
 gregtech:meta_block_compressed_3:0, Block of Indium
 gregtech:meta_block_compressed_3:2, Block of Iridium
 gregtech:meta_block_compressed_3:7, Block of Lead
 gregtech:meta_block_compressed_3:13, Block of Manganese
-gregtech:meta_block_compressed_156:12, Block of Endereye
-gregtech:meta_block_compressed_156:14, Block of Red Steel
-gregtech:meta_block_compressed_156:15, Block of Blue Steel
 gregtech:meta_block_compressed_128:1, Block of Flint
 gregtech:meta_block_compressed_128:14, Block of Rhodium Plated Palladium
-gregtech:meta_block_compressed_187:8, Block of Stellite-100
-gregtech:meta_block_compressed_187:9, Block of Watertight Steel
-gregtech:meta_block_compressed_187:10, Block of Maraging Steel 300
-gregtech:meta_block_compressed_187:11, Block of Hastelloy-C276
-gregtech:meta_block_compressed_187:12, Block of Hastelloy-X
-gregtech:meta_block_compressed_187:13, Block of Trinaquadalloy
-gregtech:meta_block_compressed_187:14, Block of Zeron-100
-gregtech:meta_block_compressed_187:15, Block of Titanium Carbide
-gregtech:meta_block_compressed_15:10, Block of Almandine
-gregtech:meta_block_compressed_15:11, Block of Andradite
-gregtech:meta_block_compressed_15:12, Block of Annealed Copper
-gregtech:meta_block_compressed_8:0, Block of Tritanium
-gregtech:meta_block_compressed_8:1, Block of Duranium
-gregtech:meta_block_compressed_8:2, Block of Trinium
-gregtech:meta_block_compressed_22:2, Block of Indium Gallium Phosphide
-gregtech:meta_block_compressed_22:3, Block of Nickel Zinc Ferrite
-gregtech:meta_block_compressed_22:13, Block of Realgar
-gregtech:meta_block_compressed_66:12, Block of Rubber
+gregtech:meta_block_compressed_24:1, Block of Malachite
+gregtech:meta_block_compressed_24:11, Block of Magnetic Iron
+gregtech:meta_block_compressed_24:12, Block of Tungstencarbide
 gregtech:meta_block_compressed_101:0, Block of Mince Meat
-gregtech:meta_block_compressed_13:6, Block of Certus Quartz
-gregtech:meta_block_compressed_27:0, Block of Ruthenium Trinium Americium Neutronate
+gregtech:meta_block_compressed_126:0, Block of Red Garnet
+gregtech:meta_block_compressed_126:1, Block of Yellow Garnet
+gregtech:meta_block_compressed_126:13, Block of Monazite
+gregtech:meta_block_compressed_1:6, Block of Chrome
+gregtech:meta_block_compressed_1:7, Block of Cobalt
+gregtech:meta_block_compressed_1:9, Block of Copper
+gregtech:meta_block_compressed_1:11, Block of Darmstadtium
 gregtech:meta_block_compressed_100:2, Block of Nether Star
+gregtech:meta_block_frame_16:3, Brass Frame Box
+gregtech:meta_block_frame_16:4, Bronze Frame Box
+gregtech:meta_block_frame_0:2, Aluminium Frame Box
+gregtech:meta_block_frame_188:12, HSLA Steel Frame Box
+gregtech:meta_block_frame_188:14, Incoloy-MA956 Frame Box
+gregtech:meta_block_frame_156:15, Blue Steel Frame Box
+gregtech:meta_block_frame_7:1, Titanium Frame Box
+gregtech:meta_block_frame_7:3, Tungsten Frame Box
+gregtech:meta_block_frame_7:15, Neutronium Frame Box
+gregtech:meta_block_frame_2:1, Europium Frame Box
+gregtech:meta_block_frame_18:15, Bismuth Bronze Frame Box
 gregtech:meta_block_frame_20:3, Stainless Steel Frame Box
 gregtech:meta_block_frame_20:4, Steel Frame Box
-gregtech:meta_block_frame_24:12, Tungstencarbide Frame Box
-gregtech:meta_block_frame_63:8, Polytetrafluoroethylene (PTFE) Frame Box
 gregtech:meta_block_frame_103:0, Treated Wood Frame Box
-gregtech:meta_block_frame_156:15, Blue Steel Frame Box
+gregtech:meta_block_frame_3:3, Iron Frame Box
+gregtech:meta_block_frame_127:10, Naquadah Alloy Frame Box
 gregtech:meta_block_frame_157:4, HSS-G Frame Box
 gregtech:meta_block_frame_157:7, HSS-E Frame Box
 gregtech:meta_block_frame_157:8, HSS-S Frame Box
-gregtech:meta_block_frame_127:10, Naquadah Alloy Frame Box
-gregtech:meta_block_frame_188:12, HSLA Steel Frame Box
-gregtech:meta_block_frame_188:14, Incoloy-MA956 Frame Box
 gregtech:meta_block_frame_187:9, Watertight Steel Frame Box
 gregtech:meta_block_frame_187:10, Maraging Steel 300 Frame Box
 gregtech:meta_block_frame_187:11, Hastelloy-C276 Frame Box
 gregtech:meta_block_frame_187:12, Hastelloy-X Frame Box
+gregtech:meta_block_frame_63:8, Polytetrafluoroethylene (PTFE) Frame Box
 gregtech:meta_block_frame_125:13, Tungstensteel Frame Box
-gregtech:meta_block_frame_2:1, Europium Frame Box
-gregtech:meta_block_frame_16:3, Brass Frame Box
-gregtech:meta_block_frame_16:4, Bronze Frame Box
-gregtech:meta_block_frame_18:15, Bismuth Bronze Frame Box
-gregtech:meta_block_frame_7:1, Titanium Frame Box
-gregtech:meta_block_frame_7:3, Tungsten Frame Box
-gregtech:meta_block_frame_7:15, Neutronium Frame Box
 gregtech:meta_block_frame_17:15, Invar Frame Box
-gregtech:meta_block_frame_3:3, Iron Frame Box
+gregtech:meta_block_frame_24:12, Tungstencarbide Frame Box
 gregtech:meta_block_frame_8:0, Tritanium Frame Box
 gregtech:meta_block_frame_101:1, Wood Frame Box
-gregtech:meta_block_frame_0:2, Aluminium Frame Box
 gcym:unique_casing:0, Crushing Wheels
 gcym:unique_casing:1, Slicing Blades
 gcym:unique_casing:2, Electrolytic Cell

--- a/overrides/config/gregtech.cfg
+++ b/overrides/config/gregtech.cfg
@@ -11,7 +11,7 @@ general {
     "client options" {
         # Whether or not to enable Emissive Textures for GregTech Casings when the multiblock is working (EBF coils, Fusion Casings, etc.).
         # Default: false
-        B:casingsActiveEmissiveTextures=true
+        B:casingsActiveEmissiveTextures=false
 
         # The default color to overlay onto machines.
         # 16777215 (0xFFFFFF in decimal) is no coloring (like GTCE).

--- a/overrides/scripts/_Init.zs
+++ b/overrides/scripts/_Init.zs
@@ -74,12 +74,12 @@ global greenhouse as RecipeMap = FactoryRecipeMap.start("greenhouse")
     .build();
 
 global voidoreminer as RecipeMap = FactoryRecipeMap.start("voidoreminer")
-    .minInputs(0)
+    .minInputs(1)
     .maxInputs(1)
     .minOutputs(1)
     .maxOutputs(1)
-    .minFluidInputs(0)
-    .maxFluidInputs(1)
+    .minFluidInputs(2)
+    .maxFluidInputs(2)
     .minFluidOutputs(0)
     .maxFluidOutputs(0)
     .build();

--- a/overrides/scripts/global/JEI.zs
+++ b/overrides/scripts/global/JEI.zs
@@ -15,7 +15,7 @@ JEI.addDescription(<appliedenergistics2:part:469>, "Made by right-clicking ME P2
 JEI.addDescription(<appliedenergistics2:part:463>, "Made by right-clicking ME P2P Tunnel with a bucket.");
 
 <appliedenergistics2:part:470>.addTooltip(format.green("Made by right-clicking ME P2P Tunnel with a GTCEu energy cable."));
-JEI.addDescription(<appliedenergistics2:part:462>, "Made by right-clicking ME P2P Tunnel with a GTCEu energy cable.");
+JEI.addDescription(<appliedenergistics2:part:470>, "Made by right-clicking ME P2P Tunnel with a GTCEu energy cable.");
 
 <appliedenergistics2:part:462>.addTooltip(format.green("Made by right-clicking ME P2P Tunnel with a chest."));
 JEI.addDescription(<appliedenergistics2:part:462>, "Made by right-clicking ME P2P Tunnel with a chest.");

--- a/overrides/scripts/machines.zs
+++ b/overrides/scripts/machines.zs
@@ -62,32 +62,31 @@ Builder.start("voidoreminer", 32001)
             .aisle("CCCCC", "FCCCF", "FCCCF", "FCCCF", "#FFF#", "##F##", "##F##", "#####", "#####", "#####")
             .aisle("CCSCC", "#FFF#", "#FFF#", "#FFF#", "#####", "#####", "#####", "#####", "#####", "#####")
             .where("S", controller.self())
-            .where("C", CTPredicate.states(<metastate:gregtech:metal_casing:9>).setMinGlobalLimited(49) | controller.autoAbilities())
-            .where("F", CTPredicate.states(<metastate:gregtech:meta_block_frame_63:8>))
+            .where("C", CTPredicate.states(<metastate:gregtech:metal_casing:10>).setMinGlobalLimited(48) | controller.autoAbilities())
+            .where("F", CTPredicate.states(<metastate:gregtech:meta_block_frame_157:7>))
             .where("#", CTPredicate.getAir())
             .build();
     } as IPatternBuilderFunction)
     .withRecipeMap(<recipemap:voidoreminer>)
-    .withBaseTexture(<metastate:gregtech:metal_casing:9>)
+    .withBaseTexture(<metastate:gregtech:metal_casing:10>)
     .buildAndRegister();
 assembly_line.recipeBuilder()
     .inputs([<metaitem:hull.zpm>])
     .inputs([<metaitem:frameNaquadahAlloy> * 4])
-    .inputs([<metaitem:circuit.wetware_assembly> * 4])
+    .inputs([<ore:circuitUltimate> * 4])
     .inputs([<metaitem:electric.motor.zpm> * 4])
     .inputs([<metaitem:electric.pump.zpm> * 4])
     .inputs([<metaitem:conveyor.module.zpm> * 4])
     .inputs([<metaitem:robot.arm.zpm> * 4])
     .inputs([<metaitem:emitter.zpm> * 4])
     .inputs([<metaitem:sensor.zpm> * 4])
-    .inputs([<metaitem:fluid.regulator.zpm> * 4])
     .inputs([<metaitem:gearNaquadahAlloy>])
     .fluidInputs(<liquid:soldering_alloy> * 8000)
     .outputs([<metaitem:multiblocktweaker:voidoreminer>])
     .duration(600)
     .EUt(122880)
     .buildAndRegister();
-JEI.addDescription(<metaitem:multiblocktweaker:voidoreminer>, "When you put the ore you want to mine into the Input Bus, the same ore will be mined at ZPM, consuming 10s and 19200L of Drilling Fluid.");
+JEI.addDescription(<metaitem:multiblocktweaker:voidoreminer>, "When you put the ore you want to mine into the Input Bus, it will mine the same ore you put in. The mining time is 1 second, and it costs 19200L of Drilling Fluid and 50L of Dew of the Void.");
 
 
 
@@ -252,7 +251,6 @@ var oresAny as IItemStack[] = [
     <gregtech:ore_nether_quartz_0:*>,
     <gregtech:ore_quartzite_0:*>,
     <gregtech:ore_mica_0:*>,
-    <gregtech:ore_cobalt_0:*>,
     <gregtech:ore_cobaltite_0:*>,
     <gregtech:ore_sodalite_0:*>,
     <gregtech:ore_opal_0:*>,
@@ -290,7 +288,31 @@ var oresAny as IItemStack[] = [
     <gregtech:ore_tungstate_0:*>,
     <gregtech:ore_uraninite_0:*>,
     <gregtech:ore_pyrochlore_0:*>,
-    <gregtech:ore_oilsands_0:*>
+    <gregtech:ore_oilsands_0:*>,
+    <gregtech:ore_monazite_0:*>,
+    <gregtech:ore_pitchblende_0:*>,
+    <gregtech:ore_fullers_earth_0:*>,
+    <gregtech:ore_vanadium_magnetite_0:*>,
+    <gregtech:ore_garnet_yellow_0:*>,
+    <gregtech:ore_apatite_0:*>,
+    <gregtech:ore_olivine_0:*>,
+    <gregtech:ore_soapstone_0:*>,
+    <gregtech:ore_alunite_0:*>,
+    <gregtech:ore_spodumene_0:*>,
+    <gregtech:ore_pentlandite_0:*>,
+    <gregtech:ore_chalcocite_0:*>,
+    <gregtech:ore_bornite_0:*>,
+    <gregtech:ore_graphite_0:*>,
+    <gregtech:ore_yellow_limonite_0:*>,
+    <gregtech:ore_sapphire_0:*>,
+    <gregtech:ore_pyrite_0:*>,
+    <gregtech:ore_magnesite_0:*>,
+    <gregtech:ore_galena_0:*>,
+    <gregtech:ore_diamond_0:*>,
+    <gregtech:ore_cooperite_0:*>,
+    <gregtech:ore_banded_iron_0:*>,
+    <gregtech:ore_palladium_0:*>,
+    <gregtech:ore_beryllium_0:*>
 ];
 var ores as IItemStack[] = [
     <gregtech:ore_copper_0>,
@@ -337,7 +359,6 @@ var ores as IItemStack[] = [
     <gregtech:ore_nether_quartz_0>,
     <gregtech:ore_quartzite_0>,
     <gregtech:ore_mica_0>,
-    <gregtech:ore_cobalt_0>,
     <gregtech:ore_cobaltite_0>,
     <gregtech:ore_sodalite_0>,
     <gregtech:ore_opal_0>,
@@ -375,14 +396,39 @@ var ores as IItemStack[] = [
     <gregtech:ore_tungstate_0>,
     <gregtech:ore_uraninite_0>,
     <gregtech:ore_pyrochlore_0>,
-    <gregtech:ore_oilsands_0>
+    <gregtech:ore_oilsands_0>,
+    <gregtech:ore_monazite_0>,
+    <gregtech:ore_pitchblende_0>,
+    <gregtech:ore_fullers_earth_0>,
+    <gregtech:ore_vanadium_magnetite_0>,
+    <gregtech:ore_garnet_yellow_0>,
+    <gregtech:ore_apatite_0>,
+    <gregtech:ore_olivine_0>,
+    <gregtech:ore_soapstone_0>,
+    <gregtech:ore_alunite_0>,
+    <gregtech:ore_spodumene_0>,
+    <gregtech:ore_pentlandite_0>,
+    <gregtech:ore_chalcocite_0>,
+    <gregtech:ore_bornite_0>,
+    <gregtech:ore_graphite_0>,
+    <gregtech:ore_yellow_limonite_0>,
+    <gregtech:ore_sapphire_0>,
+    <gregtech:ore_pyrite_0>,
+    <gregtech:ore_magnesite_0>,
+    <gregtech:ore_galena_0>,
+    <gregtech:ore_diamond_0>,
+    <gregtech:ore_cooperite_0>,
+    <gregtech:ore_banded_iron_0>,
+    <gregtech:ore_palladium_0>,
+    <gregtech:ore_beryllium_0>
 ];
 for i, ore in ores {
     voidoreminer.recipeBuilder()
         .inputs([oresAny[i]])
         .fluidInputs([<liquid:drilling_fluid> * 19200])
+        .fluidInputs([<liquid:ender_distillation> * 10])
         .outputs([ore * 64])
-        .duration(200)
+        .duration(20)
         .EUt(122880)
         .buildAndRegister();
 }

--- a/overrides/scripts/machines.zs
+++ b/overrides/scripts/machines.zs
@@ -86,7 +86,7 @@ assembly_line.recipeBuilder()
     .duration(600)
     .EUt(122880)
     .buildAndRegister();
-JEI.addDescription(<metaitem:multiblocktweaker:voidoreminer>, "When you put the ore you want to mine into the Input Bus, it will mine the same ore you put in. The mining time is 1 second, and it costs 19200L of Drilling Fluid and 50L of Dew of the Void.");
+JEI.addDescription(<metaitem:multiblocktweaker:voidoreminer>, "When you put the ore you want to mine into the Input Bus, it will mine the same ore you put in. The mining time is 1 second, and it costs 19200L of Drilling Fluid and 10L of Dew of the Void.");
 
 
 

--- a/overrides/scripts/materials.zs
+++ b/overrides/scripts/materials.zs
@@ -7,23 +7,6 @@ import mods.gregtech.material.MaterialRegistry;
 
 
 ########################################
-# Items
-########################################
-#
-// MaterialBuilder(32117, "")
-//     .dust()
-//     .color(0x942323)
-//     .build();
-
-#
-// MaterialBuilder(32118, "")
-//     .dust()
-//     .color(0x942323)
-//     .build();
-
-
-
-########################################
 # Fluid
 ########################################
 # Naquadah Rocket Fuel

--- a/overrides/scripts/normal/AppliedenErgistics.zs
+++ b/overrides/scripts/normal/AppliedenErgistics.zs
@@ -1223,7 +1223,13 @@ recipes.remove(<appliedenergistics2:quartz_block>);
 recipes.remove(<appliedenergistics2:quartz_pillar>);
 recipes.remove(<appliedenergistics2:chiseled_quartz_block>);
 compressor.recipeBuilder()
-    .inputs([<ore:crystalCertusQuartz> * 4 | <ore:crystalPureCertusQuartz> * 8])
+    .inputs([<ore:crystalCertusQuartz> * 4])
+    .outputs([<appliedenergistics2:quartz_block>])
+    .duration(300)
+    .EUt(2)
+    .buildAndRegister();
+compressor.recipeBuilder()
+    .inputs([<ore:crystalPureCertusQuartz> * 8])
     .outputs([<appliedenergistics2:quartz_block>])
     .duration(300)
     .EUt(2)
@@ -1232,7 +1238,13 @@ compressor.recipeBuilder()
 # Fluix Block
 recipes.remove(<appliedenergistics2:fluix_block>);
 compressor.recipeBuilder()
-    .inputs([<ore:crystalFluix> * 4 | <ore:crystalPureFluix> * 8])
+    .inputs([<ore:crystalFluix> * 4])
+    .outputs([<appliedenergistics2:fluix_block>])
+    .duration(300)
+    .EUt(2)
+    .buildAndRegister();
+compressor.recipeBuilder()
+    .inputs([<ore:crystalPureFluix> * 8])
     .outputs([<appliedenergistics2:fluix_block>])
     .duration(300)
     .EUt(2)

--- a/overrides/scripts/normal/GregTech.zs
+++ b/overrides/scripts/normal/GregTech.zs
@@ -131,11 +131,11 @@ chemical_reactor.recipeBuilder()
 mixer.recipeBuilder()
     .fluidInputs([
         <liquid:naquadah> * 1000,
-        <liquid:rocket_fuel> * 1000
+        <liquid:rocket_fuel> * 5000
     ])
     .fluidOutputs([<liquid:naquadah_rocket_fuel> * 6000])
-    .duration(60)
-    .EUt(16)
+    .duration(20)
+    .EUt(1920)
     .buildAndRegister();
 RecipeMaps.COMBUSTION_GENERATOR_FUELS.recipeBuilder()
     .fluidInputs([<liquid:naquadah_rocket_fuel>])

--- a/overrides/scripts/normal/OpenComputers.zs
+++ b/overrides/scripts/normal/OpenComputers.zs
@@ -33,7 +33,7 @@ recipes.remove(<opencomputers:material:6>);
 assembler.recipeBuilder()
     .circuit(0)
     .inputs([
-        <ore:stickIron> * 3,
+        <ore:boltIron> * 3,
         <ore:dustRedstone>
     ])
     .outputs([<opencomputers:material:6>])

--- a/overrides/scripts/normal/end/Gregtech.zs
+++ b/overrides/scripts/normal/end/Gregtech.zs
@@ -26,18 +26,6 @@ import mods.jei.JEI;
 );
 
 # Infinite GT Energy Unit Emitter
-// TableCrafting.addShaped(0, <gregtech:machine:1650>, [
-//     [<enderio:block_cap_bank>.withTag({"enderio:energy": 50000000}), <ore:blockUraniumRhodiumDinaquadide>, <ore:blockUraniumRhodiumDinaquadide>, <ore:blockUraniumRhodiumDinaquadide>, <contenttweaker:creativecomponent>, <ore:blockUraniumRhodiumDinaquadide>, <ore:blockUraniumRhodiumDinaquadide>, <ore:blockUraniumRhodiumDinaquadide>, <enderio:block_cap_bank>.withTag({"enderio:energy": 50000000})], 
-//     [<ore:blockUraniumRhodiumDinaquadide>, <appliedenergistics2:creative_energy_cell>, <appliedenergistics2:creative_energy_cell>, <appliedenergistics2:creative_energy_cell>, <gregtech:meta_item_1:753>, <appliedenergistics2:creative_energy_cell>, <appliedenergistics2:creative_energy_cell>, <appliedenergistics2:creative_energy_cell>, <ore:blockUraniumRhodiumDinaquadide>], 
-//     [<ore:blockUraniumRhodiumDinaquadide>, <appliedenergistics2:creative_energy_cell>, <contenttweaker:creativecomponent>, <appliedenergistics2:creative_energy_cell>, <gregtech:meta_item_1:753>, <appliedenergistics2:creative_energy_cell>, <contenttweaker:creativecomponent>, <appliedenergistics2:creative_energy_cell>, <ore:blockUraniumRhodiumDinaquadide>], 
-//     [<ore:blockUraniumRhodiumDinaquadide>, <appliedenergistics2:creative_energy_cell>, <appliedenergistics2:creative_energy_cell>, <appliedenergistics2:creative_energy_cell>, <gregtech:meta_item_1:753>, <appliedenergistics2:creative_energy_cell>, <appliedenergistics2:creative_energy_cell>, <appliedenergistics2:creative_energy_cell>, <ore:blockUraniumRhodiumDinaquadide>], 
-//     [<contenttweaker:creativecomponent>, <gregtech:meta_item_1:753>, <gregtech:meta_item_1:753>, <gregtech:meta_item_1:753>, <gregtech:meta_item_1:1000>, <gregtech:meta_item_1:753>, <gregtech:meta_item_1:753>, <gregtech:meta_item_1:753>, <contenttweaker:creativecomponent>], 
-//     [<ore:blockUraniumRhodiumDinaquadide>, <appliedenergistics2:creative_energy_cell>, <appliedenergistics2:creative_energy_cell>, <appliedenergistics2:creative_energy_cell>, <gregtech:meta_item_1:753>, <appliedenergistics2:creative_energy_cell>, <appliedenergistics2:creative_energy_cell>, <appliedenergistics2:creative_energy_cell>, <ore:blockUraniumRhodiumDinaquadide>], 
-//     [<ore:blockUraniumRhodiumDinaquadide>, <appliedenergistics2:creative_energy_cell>, <contenttweaker:creativecomponent>, <appliedenergistics2:creative_energy_cell>, <gregtech:meta_item_1:753>, <appliedenergistics2:creative_energy_cell>, <contenttweaker:creativecomponent>, <appliedenergistics2:creative_energy_cell>, <ore:blockUraniumRhodiumDinaquadide>], 
-//     [<ore:blockUraniumRhodiumDinaquadide>, <appliedenergistics2:creative_energy_cell>, <appliedenergistics2:creative_energy_cell>, <appliedenergistics2:creative_energy_cell>, <gregtech:meta_item_1:753>, <appliedenergistics2:creative_energy_cell>, <appliedenergistics2:creative_energy_cell>, <appliedenergistics2:creative_energy_cell>, <ore:blockUraniumRhodiumDinaquadide>], 
-//     [<enderio:block_cap_bank>.withTag({"enderio:energy": 50000000}), <ore:blockUraniumRhodiumDinaquadide>, <ore:blockUraniumRhodiumDinaquadide>, <ore:blockUraniumRhodiumDinaquadide>, <contenttweaker:creativecomponent>, <ore:blockUraniumRhodiumDinaquadide>, <ore:blockUraniumRhodiumDinaquadide>, <ore:blockUraniumRhodiumDinaquadide>, <enderio:block_cap_bank>.withTag({"enderio:energy": 50000000})]
-// ]);
-
 assembly_line.recipeBuilder()
     .inputs([<enderio:block_cap_bank>.withTag({"enderio:energy": 50000000})])
     .inputs([<gregtech:meta_item_1:753> * 2])


### PR DESCRIPTION
# Update mods
* AE2 Unofficial Extended Life
* GregTech Food Option

# Change config
## AE2WirelessTerminals
* DropsBooster -> all off
* UseOldInfinityMechanic -> true

# GregTech
* casingsActiveEmissiveTextures -> false

# Modpack fix
* GTCEu P2P description is in the other section.
* Adjusted the way Naquadah Rocket Fuel is created.
* Some ore could not be mined at the Void Ore Drilling Plant.
* Changed the way the Void Ore Drilling Plant is assembled and the recipe on the assembly line.
* Adjusted the mining time of the Void Ore Drilling Plant.
* The Void Ore Drilling Plant now requires 10L of Dew of the Void to operate.

# Fix recipes
## Open Computers
* Transistor