### PR TITLE
[update] v1.2.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,13 @@
 # v1.2.5
 ## Modpack fix
-* [Feature] AE2 Unofficial Extended Lifeの翻訳 (#90)
-* [Bug] Input Bus is not set for Void Ore Miner (#94)
+* [Bug] Void Ore Miner didn't require Input Bus (#94)
 * [Fix] AE2 tooltip (#97)
-* [Rebert] null mk6 (#98)
+* [Rebert] /dank/null/ mk6 (#98)
 * [Fix] Centrifuge recipe (#103)
 * [Fix] Mod configs (#106)
 
 ## Modpack update
+* [Update] AE2 Unofficial Extended Lifeの翻訳 (#90)
 * [Update] Default ranks (#100)
 * [Update] Quest include v0.9.0 (#107)
 * [Update] New and update mods (#104)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# v1.3.0
+# v1.2.5
 ## Modpack fix
 * [Feature] AE2 Unofficial Extended Lifeの翻訳 (#90)
 * [Bug] Input Bus is not set for Void Ore Miner (#94)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # v1.3.0
 ## Modpack fix
-* [Feature] AE2 Unofficial Extended Lifeの翻訳 (#85)
-* [Bug] Input Bus is not set for Void Ore Miner (#93)
+* [Feature] AE2 Unofficial Extended Lifeの翻訳 (#90)
+* [Bug] Input Bus is not set for Void Ore Miner (#94)
 * [Fix] AE2 tooltip (#97)
 * [Rebert] null mk6 (#98)
 * [Fix] Centrifuge recipe (#103)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,46 @@
+# v1.3.0
+## Modpack fix
+* [Feature] AE2 Unofficial Extended Lifeの翻訳 (#85)
+* [Bug] Input Bus is not set for Void Ore Miner (#93)
+* [Fix] AE2 tooltip (#97)
+* [Rebert] null mk6 (#98)
+* [Fix] Centrifuge recipe (#103)
+* [Fix] Mod configs (#106)
+
+## Modpack update
+* [Update] Default ranks (#100)
+* [Update] Quest include v0.9.0 (#107)
+* [Update] New and update mods (#104)
+* [Update] Spot Loader (#102)
+
+## New mods
+* Craft Presence
+* Fluidlogged API
+
+## Update mods
+* AE2 Unofficial Extended Life
+* OAuth
+* Trash Cans
+
+## Update recipes
+### ChickenChunks
+* Chunk Loader
+* Spot Loader
+
+### GregTech
+* Glowstone Dust
+
+## New recipes
+* No change
+
+## Fix recipes
+* No change
+
+## Del recipes
+* No change
+
+* * * 
+
 # v1.2.0
 ## Modpack fix
 * Fixed unexpected behavior of Multiblock.

--- a/manifest.json
+++ b/manifest.json
@@ -11,7 +11,7 @@
   "manifestType": "minecraftModpack",
   "manifestVersion": 1,
   "name": "GregTech Expert 2",
-  "version": "v1.2.0",
+  "version": "v1.3.0",
   "author": "tier940",
   "files": [
     {

--- a/manifest.json
+++ b/manifest.json
@@ -11,7 +11,7 @@
   "manifestType": "minecraftModpack",
   "manifestVersion": 1,
   "name": "GregTech Expert 2",
-  "version": "v1.3.0",
+  "version": "v1.2.5",
   "author": "tier940",
   "files": [
     {


### PR DESCRIPTION
# Modpack fix
* [Bug] Void Ore Miner didn't require Input Bus (#94)
* [Fix] AE2 tooltip (#97)
* [Rebert] /dank/null/ mk6 (#98)
* [Fix] Centrifuge recipe (#103)
* [Fix] Mod configs (#106)

# Modpack update
* [Update] AE2 Unofficial Extended Lifeの翻訳 (#90)
* [Update] Default ranks (#100)
* [Update] Quest include v0.9.0 (#107)
* [Update] New and update mods (#104)
* [Update] Spot Loader (#102)

# New mods
* Craft Presence
* Fluidlogged API

# Update mods
* AE2 Unofficial Extended Life
* OAuth
* Trash Cans

# Update recipes
## ChickenChunks
* Chunk Loader
* Spot Loader

## GregTech
* Glowstone Dust

# New recipes
* No change

# Fix recipes
* No change

# Del recipes
* No change