### PR TITLE
Update v2.6.10

### DIFF
--- a/CHANGELOG_v2.md
+++ b/CHANGELOG_v2.md
@@ -5,7 +5,7 @@
 ## Downgrade mod
 - RoughlyEnoughIDs
 
-## Update mod
+## Update mods
 - Better Questing Unofficial
 - AE2 Fluid Crafting Rework
 - PackagedAuto
@@ -25,7 +25,7 @@
 - Item Filters
 - FTB Quests (Forge)
 
-## Move mods
+## Move mod
 - FTB Backups (Forge) -> Advanced Backups
 
 ## Update mods
@@ -45,7 +45,7 @@
 
 * * *
 
-# 2.6.10
+# v2.6.10
 ## Modpack information
 - This is a backport including 2.7.1 mod updates and updates that do not break the environment as 2.6.10.
 - Includes multiplayer issues, performance tweaks and mod updates.
@@ -53,8 +53,7 @@
 ## Downgrade mod
 - RoughlyEnoughIDs
 
-## Update mod
-- Better Questing Unofficial
+## Update mods
 - AE2 Fluid Crafting Rework
 - PackagedAuto
 - ConfigAnytime
@@ -110,7 +109,7 @@
 - Tank
 - Chest
 
-## Move mods
+## Move mod
 - File Director -> GTExpert-Core
 
 ## Update mods


### PR DESCRIPTION
# v2.6.10
## Modpack information
- This is a backport including 2.7.1 mod updates and updates that do not break the environment as 2.6.10.
- Includes multiplayer issues, performance tweaks and mod updates.
    - Fix: https://github.com/GTModpackTeam/GregTech-Expert-2/issues/385
    - Fix: https://github.com/GTModpackTeam/GregTech-Expert-2/issues/386

## Downgrade mod
- RoughlyEnoughIDs

## Update mod
- AE2 Fluid Crafting Rework
- PackagedAuto
- ConfigAnytime
- VintageFix
- JourneyMap
- GTExpert-Core
