### PR TITLE
 LWJGL3版の導入ガイドをリリースページに追記

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -122,6 +122,10 @@ jobs:
         with:
           tag_name: ${{ env.VERSION_LWJGL3 }}
           prerelease: true
+          body: |
+            Note - This is LWJGL3 build and only available for MMC / PrismLauncher.
+            FOLLOW THE INSTALLATION GUIDE [HERE](https://github.com/GTModpackTeam/GregTech-Expert-2/blob/main/cmmc/README.md).
+            ---
           generate_release_notes: true
           files: |
             ./${{ env.NAME }}-${{ env.VERSION_LWJGL3 }}-cmmc.zip

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -130,6 +130,10 @@ jobs:
         uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ env.VERSION_LWJGL3 }}
+          body: |
+            Note - This is LWJGL3 build and only available for MMC / PrismLauncher.
+            FOLLOW THE INSTALLATION GUIDE [HERE](https://github.com/GTModpackTeam/GregTech-Expert-2/blob/main/cmmc/README.md).
+            ---
           generate_release_notes: true
           files: |
             ./${{ env.NAME }}-${{ env.VERSION_LWJGL3 }}-cmmc.zip

--- a/cmmc/README.md
+++ b/cmmc/README.md
@@ -1,4 +1,4 @@
-# GregTech Expert 2 for LWJGL3 Version - (Powerd by [CleanroomMMC](https://github.com/CleanroomMC/CleanroomMMC))
+# GregTech Expert 2 for LWJGL3 Version - (Powered by [CleanroomMMC](https://github.com/CleanroomMC/CleanroomMMC))
 
 ## About
 - This is the first ModPack created(probably) to promote [CleanroomMC](https://github.com/CleanroomMC), which runs on LWJGL version 3 in Minecraft 1.12.2 and aims to run Java 21, optimize, and much more.


### PR DESCRIPTION
## LWJGL3ビルドのリリースページに、ScalarやFugueの導入ガイドへのリンクを追加。
![Screenshot 2024-08-06 072344](https://github.com/user-attachments/assets/9f9216aa-dafb-42f2-be30-768a9d0ea0c7)

- 文字が全て太字なのはaction-gh-releaseの仕様。READMEに記載の限りでは太字を無効化するプロパティは無い模様。
- 重大なtypoを修正 (powerd -> powered)
- Large Essentia Generatorは追加していません